### PR TITLE
feat: add pension overview screen

### DIFF
--- a/lib/screens/edit_statement_screen.dart
+++ b/lib/screens/edit_statement_screen.dart
@@ -19,9 +19,11 @@ class EditStatementScreen extends StatefulWidget {
   // If editing, this is the statement record we are editing.
   // If adding new this will be null
   final Statement? statement;
+  final Pension? parentPension;
   final DatabaseService? databaseService;
 
-  const EditStatementScreen({super.key, this.statement, this.databaseService});
+  const EditStatementScreen(
+      {super.key, this.parentPension, this.statement, this.databaseService});
 
   @override
   State<EditStatementScreen> createState() => _EditStatmentScreenState();
@@ -57,6 +59,8 @@ class _EditStatmentScreenState extends State<EditStatementScreen> {
           CurrencyHelper.formatCurrency(widget.statement!.yearlyCharges);
       transferValueController.text =
           CurrencyHelper.formatCurrency(widget.statement!.transferValue);
+    } else if (widget.parentPension != null) {
+      _pensionId = widget.parentPension!.pensionId;
     }
   }
 
@@ -257,10 +261,10 @@ class _EditStatmentScreenState extends State<EditStatementScreen> {
           widget.statement!.statementId,
           _pensionId!,
           _statementDate!,
-          double.parse(planValueController.text),
-          double.parse(projectedAnnualAmountController.text),
-          double.tryParse(yearlyChargesController.text),
-          double.tryParse(transferValueController.text));
+          CurrencyHelper.parseCurrency(planValueController.text)!,
+          CurrencyHelper.parseCurrency(projectedAnnualAmountController.text)!,
+          CurrencyHelper.parseCurrency(yearlyChargesController.text),
+          CurrencyHelper.parseCurrency(transferValueController.text));
     }
 
     return true;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:pension_compare/database/database_service.dart';
 import 'package:pension_compare/database/tables/pensions_with_latest_statement.dart';
-// import 'package:bin_reminder/widgets/delete_confirmation_dialog.dart';
 import 'package:pension_compare/screens/edit_pension_screen.dart';
 import 'package:pension_compare/screens/edit_statement_screen.dart';
 import 'package:pension_compare/screens/edit_state_pension_screen.dart';
 import 'package:pension_compare/widgets/pension_data_table.dart';
 import 'package:pension_compare/widgets/pension_summary_chart.dart';
+import 'package:pension_compare/screens/pension_overview_screen.dart';
 
 // TODO - Add Settings button
 class HomeScreen extends StatefulWidget {
@@ -81,20 +81,22 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 Navigator.push(
                         context,
                         MaterialPageRoute(
-                            builder: (context) => const EditPensionScreen()))
+                            builder: (context) => EditPensionScreen(
+                                databaseService: widget.databaseService)))
                     .then((_) => {setState(() {})});
               } else if (value == 'statement') {
                 Navigator.push(
                         context,
                         MaterialPageRoute(
-                            builder: (context) => const EditStatementScreen()))
+                            builder: (context) => EditStatementScreen(
+                                databaseService: widget.databaseService)))
                     .then((_) => {setState(() {})});
               } else if (value == 'state_pension') {
                 Navigator.push(
                         context,
                         MaterialPageRoute(
-                            builder: (context) =>
-                                const EditStatePensionScreen()))
+                            builder: (context) => EditStatePensionScreen(
+                                databaseService: widget.databaseService)))
                     .then((_) => {setState(() {})});
               } else if (value == 'reset_test_data') {
                 await db.populateTestData();
@@ -102,52 +104,57 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             },
           ),
         ]),
-        body: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 10.0),
-                  child: FutureBuilder<List<PensionWithLatestStatement>>(
-                    future: pensionsSummaryData,
-                    builder: (context, snapshot) {
-                      if (snapshot.connectionState == ConnectionState.waiting) {
-                        return const Center(child: CircularProgressIndicator());
-                      } else if (snapshot.hasError) {
-                        return Center(
-                            child:
-                                Text('Error loading data: ${snapshot.error}'));
-                      } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                        return const Center(
-                            child:
-                                Text('No pensions found.  Click + to add one'));
-                      } else {
-                        final List<PensionWithLatestStatement> pensions =
-                            snapshot.data!;
-                        return Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              PensionSummaryChart(pensionData: pensions),
-                              PensionDataTable(
-                                pensionDataList: pensions,
-                                onTap: (Pension pension) {
-                                  Navigator.push(
-                                          context,
-                                          MaterialPageRoute(
-                                              builder: (context) =>
-                                                  EditPensionScreen(
-                                                    pension: pension,
-                                                    databaseService: db,
-                                                  )))
-                                      .then((_) => {setState(() {})});
-                                },
-                              )
-                            ]);
-                      }
-                    },
-                  )),
-            ),
-          ],
+        body: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10.0),
+                    child: FutureBuilder<List<PensionWithLatestStatement>>(
+                      future: pensionsSummaryData,
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState ==
+                            ConnectionState.waiting) {
+                          return const Center(
+                              child: CircularProgressIndicator());
+                        } else if (snapshot.hasError) {
+                          return Center(
+                              child: Text(
+                                  'Error loading data: ${snapshot.error}'));
+                        } else if (!snapshot.hasData ||
+                            snapshot.data!.isEmpty) {
+                          return const Center(
+                              child: Text(
+                                  'No pensions found.  Click + to add one'));
+                        } else {
+                          final List<PensionWithLatestStatement> pensions =
+                              snapshot.data!;
+                          return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                PensionSummaryChart(pensionData: pensions),
+                                PensionDataTable(
+                                  pensionDataList: pensions,
+                                  onTap: (Pension pension) {
+                                    Navigator.push(
+                                            context,
+                                            MaterialPageRoute(
+                                                builder: (context) =>
+                                                    PensionOverviewScreen(
+                                                      pension: pension,
+                                                      databaseService: db,
+                                                    )))
+                                        .then((_) => {setState(() {})});
+                                  },
+                                )
+                              ]);
+                        }
+                      },
+                    )),
+              ),
+            ],
+          ),
         ));
   }
 

--- a/lib/screens/pension_overview_screen.dart
+++ b/lib/screens/pension_overview_screen.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:pension_compare/database/database_service.dart';
+import 'package:pension_compare/screens/edit_pension_screen.dart';
+import 'package:pension_compare/screens/edit_statement_screen.dart';
+import 'package:pension_compare/widgets/statement_data_table.dart';
+import 'package:pension_compare/widgets/statement_summary_chart.dart';
+
+// Pension Overview screen.  Shows an overview of one pension.
+// Contains a chart and a table of statements.  Can edit the pension or add or
+// edit statements.
+class PensionOverviewScreen extends StatefulWidget {
+  final DatabaseService databaseService;
+  final Pension pension;
+
+  const PensionOverviewScreen(
+      {super.key, required this.pension, required this.databaseService});
+
+  @override
+  State<PensionOverviewScreen> createState() => _PensionOverviewScreenState();
+}
+
+class _PensionOverviewScreenState extends State<PensionOverviewScreen>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    DatabaseService db = _getDatabaseService();
+    Future<List<Statement>> statementData =
+        db.getAllStatementsForPension(widget.pension.pensionId);
+
+    return Scaffold(
+        appBar: AppBar(title: Text(widget.pension.name), actions: [
+          IconButton(
+              icon: const Icon(Icons.add),
+              onPressed: () async {
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => EditStatementScreen(
+                              parentPension: widget.pension,
+                              databaseService: widget.databaseService,
+                            ))).then((_) => {setState(() {})});
+              }),
+          PopupMenuButton(
+            icon: const Icon(Icons.more_vert),
+            itemBuilder: (BuildContext bc) {
+              return const [
+                PopupMenuItem(
+                  value: 'pension',
+                  child: Text("Edit Pension"),
+                ),
+              ];
+            },
+            onSelected: (value) async {
+              if (value == 'pension') {
+                Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (context) =>
+                                EditPensionScreen(pension: widget.pension)))
+                    .then((_) async => {setState(() {})});
+              }
+            },
+          ),
+        ]),
+        body: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10.0),
+                    child: FutureBuilder<List<Statement>>(
+                      future: statementData,
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState ==
+                            ConnectionState.waiting) {
+                          return const Center(
+                              child: CircularProgressIndicator());
+                        } else if (snapshot.hasError) {
+                          return Center(
+                              child: Text(
+                                  'Error loading data: ${snapshot.error}'));
+                        } else if (!snapshot.hasData ||
+                            snapshot.data!.isEmpty) {
+                          return const Center(
+                              child: Text(
+                                  'No statements found.  Click + to add one'));
+                        } else {
+                          final List<Statement> statements = snapshot.data!;
+                          return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                StatementSummaryChart(
+                                    statementData: statements),
+                                StatementDataTable(
+                                  statementDataList: statements,
+                                  onTap: (Statement statement) {
+                                    Navigator.push(
+                                            context,
+                                            MaterialPageRoute(
+                                                builder: (context) =>
+                                                    EditStatementScreen(
+                                                      statement: statement,
+                                                      databaseService: db,
+                                                    )))
+                                        .then((_) => {setState(() {})});
+                                  },
+                                )
+                              ]);
+                        }
+                      },
+                    )),
+              ),
+            ],
+          ),
+        ));
+  }
+
+  DatabaseService _getDatabaseService() {
+    return widget.databaseService;
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+}

--- a/lib/widgets/statement_data_table.dart
+++ b/lib/widgets/statement_data_table.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:pension_compare/constants/custom_styles.dart';
+import 'package:pension_compare/database/database_service.dart';
+import 'package:pension_compare/helpers/currency_helper.dart';
+import 'package:pension_compare/helpers/date_helper.dart';
+
+class StatementDataTable extends StatefulWidget {
+  final List<Statement> statementDataList;
+  final Function(Statement) onTap;
+
+  const StatementDataTable(
+      {super.key, required this.statementDataList, required this.onTap});
+
+  @override
+  State<StatementDataTable> createState() => _StatementDataTableState();
+}
+
+class _StatementDataTableState extends State<StatementDataTable> {
+  @override
+  Widget build(BuildContext context) {
+    if (widget.statementDataList.isEmpty) {
+      return const Center(
+          child: Text('No statements found.  Click + to add one'));
+    }
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        showCheckboxColumn: false,
+        sortColumnIndex: 0,
+        columns: const <DataColumn>[
+          DataColumn(
+            label: Text(
+              'Statement Date',
+              style: CustomStyles.dataTableHeaderTextStyle,
+            ),
+          ),
+          DataColumn(
+            label: Text(
+              'Plan Value',
+              style: CustomStyles.dataTableHeaderTextStyle,
+            ),
+          ),
+          DataColumn(
+            label: Text(
+              'Projected',
+              style: CustomStyles.dataTableHeaderTextStyle,
+            ),
+          ),
+          DataColumn(
+            label: Text(
+              'Charges',
+              style: CustomStyles.dataTableHeaderTextStyle,
+            ),
+          ),
+          DataColumn(
+            label: Text(
+              'Transfer',
+              style: CustomStyles.dataTableHeaderTextStyle,
+            ),
+          ),
+        ],
+        rows: List<DataRow>.generate(widget.statementDataList.length,
+            (int index) {
+          Statement statementData = widget.statementDataList[index];
+          return DataRow(
+            onSelectChanged: (bool? selected) => widget.onTap(statementData),
+            cells: <DataCell>[
+              DataCell(Text(DateHelper.formatDate(statementData.statementDate)),
+                  onTap: () => widget.onTap(statementData)),
+              DataCell(
+                  Text(CurrencyHelper.formatCurrency(statementData.planValue))),
+              DataCell(Text(CurrencyHelper.formatCurrency(
+                  statementData.projectedAnnualAmount))),
+              DataCell(Text(CurrencyHelper.formatCurrency(
+                  statementData.yearlyCharges ?? 0))),
+              DataCell(Text(CurrencyHelper.formatCurrency(
+                  statementData.transferValue ?? 0)))
+            ],
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/lib/widgets/statement_summary_chart.dart
+++ b/lib/widgets/statement_summary_chart.dart
@@ -1,25 +1,26 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:pension_compare/constants/custom_styles.dart';
-import 'package:pension_compare/database/tables/pensions_with_latest_statement.dart';
+import 'package:pension_compare/database/database_service.dart';
 import 'package:pension_compare/helpers/currency_helper.dart';
+import 'package:pension_compare/helpers/date_helper.dart';
 
-class PensionSummaryChart extends StatefulWidget {
-  final List<PensionWithLatestStatement>? pensionData;
-  const PensionSummaryChart({super.key, this.pensionData});
+class StatementSummaryChart extends StatefulWidget {
+  final List<Statement>? statementData;
+  const StatementSummaryChart({super.key, this.statementData});
 
   @override
-  State<PensionSummaryChart> createState() => _PensionSummaryChartState();
+  State<StatementSummaryChart> createState() => _StatementSummaryChartState();
 }
 
-class _PensionSummaryChartState extends State<PensionSummaryChart> {
+class _StatementSummaryChartState extends State<StatementSummaryChart> {
   PensionSummaryChartStyles _selectedStyle =
       PensionSummaryChartStyles.planValue;
   static const double barWidth = 30;
 
   @override
   Widget build(BuildContext context) {
-    if (widget.pensionData == null) {
+    if (widget.statementData == null) {
       return const Center(child: Text('No data'));
     }
 
@@ -81,7 +82,7 @@ class _PensionSummaryChartState extends State<PensionSummaryChart> {
             int rodIndex,
           ) {
             return BarTooltipItem(
-              '${widget.pensionData![groupIndex].pension.name}\n'
+              '${DateHelper.formatDate(widget.statementData![groupIndex].statementDate)}\n'
               '${CurrencyHelper.formatCurrency(rod.toY)}',
               const TextStyle(
                 color: Colors.white,
@@ -93,7 +94,8 @@ class _PensionSummaryChartState extends State<PensionSummaryChart> {
       );
 
   Widget getBottomTitles(double value, TitleMeta meta) {
-    String text = widget.pensionData![value.toInt()].pension.name;
+    String text =
+        widget.statementData![value.toInt()].statementDate.year.toString();
 
     return SideTitleWidget(
       axisSide: meta.axisSide,
@@ -158,47 +160,40 @@ class _PensionSummaryChartState extends State<PensionSummaryChart> {
         end: Alignment.topCenter,
       );
 
-  List<BarChartGroupData> get planValueBarGroups => widget.pensionData!
+  List<BarChartGroupData> get planValueBarGroups => widget.statementData!
       .asMap()
       .entries
       .map((entry) => BarChartGroupData(
             x: entry.key,
-            barRods: [buildBarRodData(entry.value.latestStatement?.planValue)],
+            barRods: [buildBarRodData(entry.value.planValue)],
           ))
       .toList();
 
   List<BarChartGroupData> get projectedAnnualAmountBarGroups =>
-      widget.pensionData!
+      widget.statementData!
           .asMap()
           .entries
           .map((entry) => BarChartGroupData(
                 x: entry.key,
-                barRods: [
-                  buildBarRodData(
-                      entry.value.latestStatement?.projectedAnnualAmount)
-                ],
+                barRods: [buildBarRodData(entry.value.projectedAnnualAmount)],
               ))
           .toList();
 
-  List<BarChartGroupData> get yearlyChargesBarGroups => widget.pensionData!
+  List<BarChartGroupData> get yearlyChargesBarGroups => widget.statementData!
       .asMap()
       .entries
       .map((entry) => BarChartGroupData(
             x: entry.key,
-            barRods: [
-              buildBarRodData(entry.value.latestStatement?.yearlyCharges)
-            ],
+            barRods: [buildBarRodData(entry.value.yearlyCharges)],
           ))
       .toList();
 
-  List<BarChartGroupData> get transferValueBarGroups => widget.pensionData!
+  List<BarChartGroupData> get transferValueBarGroups => widget.statementData!
       .asMap()
       .entries
       .map((entry) => BarChartGroupData(
             x: entry.key,
-            barRods: [
-              buildBarRodData(entry.value.latestStatement?.transferValue)
-            ],
+            barRods: [buildBarRodData(entry.value.transferValue)],
           ))
       .toList();
 
@@ -241,11 +236,11 @@ class _PensionSummaryChartState extends State<PensionSummaryChart> {
 
   String getChartTitle(PensionSummaryChartStyles selectedStyle) {
     return switch (selectedStyle) {
-      PensionSummaryChartStyles.planValue => 'Pensions Plan Value',
+      PensionSummaryChartStyles.planValue => 'Pension Plan Value',
       PensionSummaryChartStyles.projectedYearlyAmount =>
-        'Pensions Projected Yearly Amount',
-      PensionSummaryChartStyles.yearlyCharges => 'Pensions Yearly Charges',
-      PensionSummaryChartStyles.transferValue => 'Pensions Transfer Value',
+        'Pension Projected Yearly Amount',
+      PensionSummaryChartStyles.yearlyCharges => 'Pension Yearly Charges',
+      PensionSummaryChartStyles.transferValue => 'Pension Transfer Value',
     };
   }
 }

--- a/test/widgets/statement_data_table_test.dart
+++ b/test/widgets/statement_data_table_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:pension_compare/helpers/currency_helper.dart';
+import 'package:pension_compare/helpers/date_helper.dart';
+import 'package:pension_compare/widgets/statement_data_table.dart';
+import 'package:pension_compare/database/database_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const String key = 'pension_data_table';
+
+Widget createDataTable(
+    List<Statement> statementData, Function(Statement) onTap) {
+  StatementDataTable dataTable = StatementDataTable(
+      key: const Key(key), statementDataList: statementData, onTap: onTap);
+
+  return StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+    return MaterialApp(
+        home: Scaffold(
+      body: dataTable,
+    ));
+  });
+}
+
+void main() {
+  group('Test building datatable', () {
+    testWidgets('show the widget with no statement records', (tester) async {
+      await tester.pumpWidget(createDataTable([], (_) {}));
+      await tester.pumpAndSettle();
+
+      expect(find.text("No statements found.  Click + to add one"),
+          findsOneWidget);
+      expect(find.byType(DataTable), findsNothing);
+    });
+
+    testWidgets('show the data table with statement record', (tester) async {
+      DateTime statementDate = DateTime.now();
+      double planValue = 1000;
+      double projectedAnnualAmount = 2000;
+      double yearlyCharges = 100;
+      double transferValue = 500;
+
+      final statementData = [
+        Statement(
+            statementId: 1,
+            pension: 1,
+            statementDate: statementDate,
+            planValue: planValue,
+            projectedAnnualAmount: projectedAnnualAmount,
+            yearlyCharges: yearlyCharges,
+            transferValue: transferValue)
+      ];
+
+      await tester.pumpWidget(createDataTable(statementData, (_) {}));
+      await tester.pumpAndSettle();
+
+      expect(find.text(DateHelper.formatDate(statementDate)), findsOneWidget);
+      expect(
+          find.text(CurrencyHelper.formatCurrency(planValue)), findsOneWidget);
+      expect(find.text(CurrencyHelper.formatCurrency(projectedAnnualAmount)),
+          findsOneWidget);
+      expect(find.text(CurrencyHelper.formatCurrency(yearlyCharges)),
+          findsOneWidget);
+      expect(find.text(CurrencyHelper.formatCurrency(transferValue)),
+          findsOneWidget);
+      expect(find.byType(DataTable), findsOneWidget);
+    });
+
+    testWidgets('is the statement record tappable', (tester) async {
+      int statementId1 = 1;
+      int statementId2 = 2;
+      int statementId3 = 3;
+      DateTime statementDate1 = DateTime(2020, 1, 1);
+      DateTime statementDate2 = DateTime(2021, 1, 1);
+      DateTime statementDate3 = DateTime(2022, 1, 1);
+      double planValue = 1000;
+      double projectedAnnualAmount = 2000;
+      double yearlyCharges = 100;
+      double transferValue = 500;
+      Statement? onTapValue;
+      bool onTapCalled = false;
+
+      onTap(Statement value) {
+        onTapValue = value;
+        onTapCalled = true;
+      }
+
+      final statementData = [
+        Statement(
+            statementId: statementId1,
+            pension: 1,
+            statementDate: statementDate1,
+            planValue: planValue,
+            projectedAnnualAmount: projectedAnnualAmount,
+            yearlyCharges: yearlyCharges,
+            transferValue: transferValue),
+        Statement(
+            statementId: statementId2,
+            pension: 1,
+            statementDate: statementDate2,
+            planValue: planValue,
+            projectedAnnualAmount: projectedAnnualAmount,
+            yearlyCharges: yearlyCharges,
+            transferValue: transferValue),
+        Statement(
+            statementId: statementId3,
+            pension: 1,
+            statementDate: statementDate3,
+            planValue: planValue,
+            projectedAnnualAmount: projectedAnnualAmount,
+            yearlyCharges: yearlyCharges,
+            transferValue: transferValue)
+      ];
+
+      await tester.pumpWidget(createDataTable(statementData, onTap));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(DateHelper.formatDate(statementDate2)));
+      await tester.pump();
+
+      expect(onTapValue, isNotNull);
+      expect(onTapValue!.statementId, equals(statementId2));
+      expect(onTapCalled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Added new Pension Overview screen, accessible when tapping pension record from home screen.  Shows list of statement records, along with chart showing statement data

Resolves #5 