### PR TITLE
feat: add delete buttons for pension and statements

### DIFF
--- a/lib/screens/edit_pension_screen.dart
+++ b/lib/screens/edit_pension_screen.dart
@@ -8,13 +8,15 @@ import 'package:pension_compare/widgets/date_field.dart';
 class EditPensionScreen extends StatefulWidget {
   static const pensionNameKey = Key('name');
   static const pensionMaturityDateKey = Key('maturityDate');
+  static const pensionDeleteKey = Key('deleteButton');
 
   // If editing, this is the pension record we are editing.
   // If adding new this will be null
   final Pension? pension;
-  final DatabaseService? databaseService;
+  final DatabaseService databaseService;
 
-  const EditPensionScreen({super.key, this.pension, this.databaseService});
+  const EditPensionScreen(
+      {super.key, this.pension, required this.databaseService});
 
   @override
   State<EditPensionScreen> createState() => _EditPensionScreenState();
@@ -123,6 +125,26 @@ class _EditPensionScreenState extends State<EditPensionScreen> {
                   const Text(
                       'This is the date you have set on this pension to retire.  You can have different dates for different pensions',
                       style: CustomStyles.infoTextStyle),
+                  // only show the delete button and spacer if the pension has been saved
+                  if (widget.pension != null) ...[
+                    CustomStyles.spacerBox,
+                    SizedBox(
+                      width: double.infinity,
+                      child: TextButton(
+                          key: EditPensionScreen.pensionDeleteKey,
+                          onPressed: () async {
+                            await _showDeleteDialog();
+                          },
+                          style: TextButton.styleFrom(
+                              side: const BorderSide(color: Colors.red),
+                              shape: const RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.zero)),
+                          child: const Text(
+                            'Delete',
+                            style: TextStyle(color: Colors.red),
+                          )),
+                    )
+                  ],
                 ],
               ),
             ),
@@ -131,9 +153,7 @@ class _EditPensionScreenState extends State<EditPensionScreen> {
   }
 
   Future<bool> _saveData() async {
-    DatabaseService db = (widget.databaseService == null)
-        ? DatabaseService.withDefaultConnection()
-        : widget.databaseService!;
+    final db = widget.databaseService;
 
     if (widget.pension == null) {
       await db.createPension(nameController.text, _maturityDate!);
@@ -173,6 +193,45 @@ class _EditPensionScreenState extends State<EditPensionScreen> {
     if (shouldDiscard ?? false) {
       if (!mounted) return;
       Navigator.of(context).pop();
+    }
+  }
+
+  Future<void> _showDeleteDialog() async {
+    if (widget.pension != null) {
+      final bool? shouldDiscard = await showDialog<bool>(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text('Delete This Pension?'),
+            content: const Text(
+                'Are you sure you want to delete this pension and any statements assigned to it?'),
+            actions: <Widget>[
+              TextButton(
+                child: const Text('Yes'),
+                onPressed: () async {
+                  await widget.databaseService
+                      .deletePension(widget.pension!.pensionId);
+
+                  if (!context.mounted) return;
+                  Navigator.pop(context, false);
+
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Pension removed successfully!'),
+                    ),
+                  );
+                },
+              ),
+              TextButton(
+                child: const Text('No'),
+                onPressed: () {
+                  Navigator.pop(context, false);
+                },
+              ),
+            ],
+          );
+        },
+      );
     }
   }
 }

--- a/lib/screens/edit_statement_screen.dart
+++ b/lib/screens/edit_statement_screen.dart
@@ -15,15 +15,19 @@ class EditStatementScreen extends StatefulWidget {
   static const projectedAnnualAmountKey = Key('projectedAnnualAmount');
   static const yearlyChargesKey = Key('yearlyCharges');
   static const transferValueKey = Key('transferValue');
+  static const statementDeleteKey = Key('deleteButton');
 
   // If editing, this is the statement record we are editing.
   // If adding new this will be null
   final Statement? statement;
   final Pension? parentPension;
-  final DatabaseService? databaseService;
+  final DatabaseService databaseService;
 
   const EditStatementScreen(
-      {super.key, this.parentPension, this.statement, this.databaseService});
+      {super.key,
+      this.parentPension,
+      this.statement,
+      required this.databaseService});
 
   @override
   State<EditStatementScreen> createState() => _EditStatmentScreenState();
@@ -227,6 +231,26 @@ class _EditStatmentScreenState extends State<EditStatementScreen> {
                       _unsavedChanges = true;
                     },
                   ),
+                  // only show the delete button and spacer if the statement has been saved
+                  if (widget.statement != null) ...[
+                    CustomStyles.spacerBox,
+                    SizedBox(
+                      width: double.infinity,
+                      child: TextButton(
+                          key: EditStatementScreen.statementDeleteKey,
+                          onPressed: () async {
+                            await _showDeleteDialog();
+                          },
+                          style: TextButton.styleFrom(
+                              side: const BorderSide(color: Colors.red),
+                              shape: const RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.zero)),
+                          child: const Text(
+                            'Delete',
+                            style: TextStyle(color: Colors.red),
+                          )),
+                    )
+                  ],
                 ],
               ),
             ),
@@ -234,19 +258,13 @@ class _EditStatmentScreenState extends State<EditStatementScreen> {
         ));
   }
 
-  DatabaseService _getDatabaseService() {
-    return (widget.databaseService == null)
-        ? DatabaseService.withDefaultConnection()
-        : widget.databaseService!;
-  }
-
   void _loadData() {
-    DatabaseService db = _getDatabaseService();
+    DatabaseService db = widget.databaseService;
     _pensions = db.getAllPensions();
   }
 
   Future<bool> _saveData() async {
-    DatabaseService db = _getDatabaseService();
+    DatabaseService db = widget.databaseService;
 
     if (widget.statement == null) {
       await db.createStatement(
@@ -298,6 +316,45 @@ class _EditStatmentScreenState extends State<EditStatementScreen> {
     if (shouldDiscard ?? false) {
       if (!mounted) return;
       Navigator.of(context).pop();
+    }
+  }
+
+  Future<void> _showDeleteDialog() async {
+    if (widget.statement != null) {
+      final bool? shouldDiscard = await showDialog<bool>(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text('Delete This Statement?'),
+            content:
+                const Text('Are you sure you want to delete this statement?'),
+            actions: <Widget>[
+              TextButton(
+                child: const Text('Yes'),
+                onPressed: () async {
+                  await widget.databaseService
+                      .deleteStatement(widget.statement!.statementId);
+
+                  if (!context.mounted) return;
+                  Navigator.pop(context, false);
+
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Statement removed successfully!'),
+                    ),
+                  );
+                },
+              ),
+              TextButton(
+                child: const Text('No'),
+                onPressed: () {
+                  Navigator.pop(context, false);
+                },
+              ),
+            ],
+          );
+        },
+      );
     }
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -46,10 +46,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             icon: const Icon(Icons.add),
             onPressed: () async {
               Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) => const EditPensionScreen()))
-                  .then((_) => {setState(() {})});
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => EditPensionScreen(
+                            databaseService: db,
+                          ))).then((_) => {setState(() {})});
             },
           ),
           PopupMenuButton(

--- a/lib/screens/pension_overview_screen.dart
+++ b/lib/screens/pension_overview_screen.dart
@@ -68,8 +68,8 @@ class _PensionOverviewScreenState extends State<PensionOverviewScreen>
                 Navigator.push(
                         context,
                         MaterialPageRoute(
-                            builder: (context) =>
-                                EditPensionScreen(pension: widget.pension)))
+                            builder: (context) => EditPensionScreen(
+                                pension: widget.pension, databaseService: db)))
                     .then((_) async => {setState(() {})});
               }
             },

--- a/test/screens/edit_pension_screen_test.dart
+++ b/test/screens/edit_pension_screen_test.dart
@@ -8,7 +8,7 @@ import 'package:mockito/mockito.dart';
 
 import 'edit_pension_screen_test.mocks.dart';
 
-Widget createEditScreen(Pension? pensionRecord, DatabaseService? db) {
+Widget createEditScreen(Pension? pensionRecord, DatabaseService db) {
   EditPensionScreen editPensionScreen =
       EditPensionScreen(pension: pensionRecord, databaseService: db);
 
@@ -19,7 +19,7 @@ Widget createEditScreen(Pension? pensionRecord, DatabaseService? db) {
 void main() {
   group('Test adding / editing of pension record', () {
     testWidgets('show the add screen with no pension record', (tester) async {
-      await tester.pumpWidget(createEditScreen(null, null));
+      await tester.pumpWidget(createEditScreen(null, MockDatabaseService()));
 
       expect(find.text("Add Pension"), findsOneWidget);
 
@@ -44,13 +44,13 @@ void main() {
       expect(
           find.byKey(EditPensionScreen.pensionMaturityDateKey), findsOneWidget);
 
-      expect(find.byType(TextButton), findsOneWidget);
+      expect(find.widgetWithText(TextButton, "Save"), findsOneWidget);
     });
 
     testWidgets('show the edit screen with a pension record', (tester) async {
       Pension p = Pension(
           pensionId: 1, name: "Test Pension", maturityDate: DateTime.now());
-      await tester.pumpWidget(createEditScreen(p, null));
+      await tester.pumpWidget(createEditScreen(p, MockDatabaseService()));
 
       expect(find.text("Edit Pension"), findsOneWidget);
       expect(find.text(p.name), findsOneWidget);
@@ -59,7 +59,7 @@ void main() {
 
     testWidgets('Set date of date picker', (WidgetTester tester) async {
       // Build your app and trigger a frame
-      await tester.pumpWidget(createEditScreen(null, null));
+      await tester.pumpWidget(createEditScreen(null, MockDatabaseService()));
 
       // Find the TextFormField by key
       final fieldFinder = find.byKey(EditPensionScreen.pensionMaturityDateKey);
@@ -110,7 +110,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Tap the save button
-      await tester.tap(find.byType(TextButton));
+      await tester.tap(find.widgetWithText(TextButton, "Save"));
 
       verify(databaseService.createPension(name, maturityDate)).called(1);
       verifyNever(databaseService.updatePension(1, name, maturityDate));
@@ -145,7 +145,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Tap the save button
-      await tester.tap(find.byType(TextButton));
+      await tester.tap(find.widgetWithText(TextButton, "Save"));
 
       verifyNever(databaseService.createPension(newName, newMaturityDate));
       verify(databaseService.updatePension(id, newName, newMaturityDate))
@@ -161,7 +161,7 @@ void main() {
       await tester.pumpWidget(createEditScreen(null, databaseService));
 
       // Tap the save button
-      await tester.tap(find.byType(TextButton));
+      await tester.tap(find.widgetWithText(TextButton, "Save"));
       await tester.pumpAndSettle();
 
       expect(find.text("Please enter some text"), findsOneWidget);
@@ -169,7 +169,119 @@ void main() {
 
       verifyZeroInteractions(databaseService);
     });
-    // test delete
+  });
+
+  group('Test delete button on add/edit pension screen', () {
+    testWidgets('delete button not visible for add new record', (tester) async {
+      final databaseService = MockDatabaseService();
+
+      await tester.pumpWidget(createEditScreen(null, databaseService));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextButton, "Delete"), findsNothing);
+
+      verifyZeroInteractions(databaseService);
+    });
+
+    testWidgets('delete button is visible for edit record', (tester) async {
+      final databaseService = MockDatabaseService();
+      final pension = Pension(
+          pensionId: 1, name: 'originalName', maturityDate: DateTime.now());
+
+      await tester.pumpWidget(createEditScreen(pension, databaseService));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextButton, "Delete"), findsOneWidget);
+
+      verifyZeroInteractions(databaseService);
+    });
+
+    testWidgets('tapping the delete button displays warning prompt',
+        (tester) async {
+      final pension = Pension(
+          pensionId: 1, name: 'originalName', maturityDate: DateTime.now());
+
+      await tester.pumpWidget(createEditScreen(pension, MockDatabaseService()));
+      await tester.pumpAndSettle();
+
+      // check the elements are not yet visible
+      expect(find.text("Delete This Pension?"), findsNothing);
+      expect(
+          find.text(
+              "Are you sure you want to delete this pension and any statements assigned to it?"),
+          findsNothing);
+
+      // Tap the delete button
+      await tester.tap(find.widgetWithText(TextButton, "Delete"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Delete This Pension?"), findsOneWidget);
+      expect(
+          find.text(
+              "Are you sure you want to delete this pension and any statements assigned to it?"),
+          findsOneWidget);
+    });
+
+    testWidgets('tapping no dismissess the warning prompt', (tester) async {
+      int pensionId = 1;
+      final pension = Pension(
+          pensionId: pensionId,
+          name: 'originalName',
+          maturityDate: DateTime.now());
+      final databaseService = MockDatabaseService();
+      when(databaseService.deletePension(pensionId))
+          .thenAnswer((_) async => pensionId);
+
+      await tester.pumpWidget(createEditScreen(pension, databaseService));
+      await tester.pumpAndSettle();
+
+      // Tap the delete button
+      await tester.tap(find.widgetWithText(TextButton, "Delete"));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, "No"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Delete This Pension?"), findsNothing);
+      expect(
+          find.text(
+              "Are you sure you want to delete this pension and any statements assigned to it?"),
+          findsNothing);
+
+      verifyNever(databaseService.deletePension(pensionId));
+    });
+
+    testWidgets(
+        'tapping yes deletes the pension and dismissess the warning prompt',
+        (tester) async {
+      int pensionId = 1;
+      final pension = Pension(
+          pensionId: pensionId,
+          name: 'originalName',
+          maturityDate: DateTime.now());
+      final databaseService = MockDatabaseService();
+      when(databaseService.deletePension(pensionId))
+          .thenAnswer((_) async => pensionId);
+
+      await tester.pumpWidget(createEditScreen(pension, databaseService));
+      await tester.pumpAndSettle();
+
+      // Tap the delete button
+      await tester.tap(find.widgetWithText(TextButton, "Delete"));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, "Yes"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Delete This Pension?"), findsNothing);
+      expect(
+          find.text(
+              "Are you sure you want to delete this pension and any statements assigned to it?"),
+          findsNothing);
+      expect(find.widgetWithText(SnackBar, "Pension removed successfully!"),
+          findsOneWidget); //look for snackbar notification
+
+      verify(databaseService.deletePension(pensionId)).called(1);
+    });
+
     // test cancel
   });
 }

--- a/test/screens/edit_statement_screen_test.dart
+++ b/test/screens/edit_statement_screen_test.dart
@@ -222,7 +222,7 @@ void main() {
           newTransferValue.toString());
 
       // Tap the save button
-      await tester.tap(find.byType(TextButton));
+      await tester.tap(find.widgetWithText(TextButton, 'Save'));
 
       verify(databaseService.getAllPensions()).called(1);
       verifyNever(databaseService.createStatement(
@@ -298,7 +298,7 @@ void main() {
           find.byKey(EditStatementScreen.transferValueKey), "invalid number");
 
       // Tap the save button
-      await tester.tap(find.byType(TextButton));
+      await tester.tap(find.widgetWithText(TextButton, 'Save'));
 
       expect(
           find.text("Please enter a value, or 0 if unknown"), findsNWidgets(2));
@@ -307,8 +307,200 @@ void main() {
       verifyNever(databaseService.createStatement(pensionId, statementDate,
           planValue, projectedAnnualAmount, yearlyCharges, transferValue));
     });
+  });
 
-    // test delete
+  group('Test delete button on add/edit statement screen', () {
+    testWidgets('delete button not visible for add new record', (tester) async {
+      int pensionId = 1;
+      String name = "Test Pension";
+      DateTime maturityDate = DateHelper.getToday();
+
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllPensions()).thenAnswer((_) async => [
+            Pension(
+                pensionId: pensionId, name: name, maturityDate: maturityDate)
+          ]);
+
+      await tester.pumpWidget(createEditScreen(null, databaseService));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextButton, "Delete"), findsNothing);
+    });
+
+    testWidgets('delete button is visible for edit record', (tester) async {
+      int pensionId = 1;
+      String name = "Test Pension";
+      DateTime maturityDate = DateHelper.getToday();
+      int statementId = 1;
+      DateTime statementDate = DateHelper.getToday();
+      double planValue = 12345.0;
+      double projectedAnnualAmount = 1234;
+      double yearlyCharges = 100;
+      double transferValue = 12345;
+
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllPensions()).thenAnswer((_) async => [
+            Pension(
+                pensionId: pensionId, name: name, maturityDate: maturityDate)
+          ]);
+      final statement = Statement(
+          statementId: statementId,
+          pension: pensionId,
+          statementDate: statementDate,
+          planValue: planValue,
+          projectedAnnualAmount: projectedAnnualAmount,
+          yearlyCharges: yearlyCharges,
+          transferValue: transferValue);
+      await tester.pumpWidget(createEditScreen(statement, databaseService));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextButton, "Delete"), findsOneWidget);
+    });
+
+    testWidgets('tapping the delete button displays warning prompt',
+        (tester) async {
+      int pensionId = 1;
+      String name = "Test Pension";
+      DateTime maturityDate = DateHelper.getToday();
+      int statementId = 1;
+      DateTime statementDate = DateHelper.getToday();
+      double planValue = 12345.0;
+      double projectedAnnualAmount = 1234;
+      double yearlyCharges = 100;
+      double transferValue = 12345;
+
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllPensions()).thenAnswer((_) async => [
+            Pension(
+                pensionId: pensionId, name: name, maturityDate: maturityDate)
+          ]);
+      final statement = Statement(
+          statementId: statementId,
+          pension: pensionId,
+          statementDate: statementDate,
+          planValue: planValue,
+          projectedAnnualAmount: projectedAnnualAmount,
+          yearlyCharges: yearlyCharges,
+          transferValue: transferValue);
+      await tester.pumpWidget(createEditScreen(statement, databaseService));
+      await tester.pumpAndSettle();
+
+      // check the elements are not yet visible
+      expect(find.text("Delete This Statement?"), findsNothing);
+      expect(find.text("Are you sure you want to delete this statement?"),
+          findsNothing);
+
+      // Tap the delete button (scroll to it first as it may be off screen)
+      final buttonFinder = find.widgetWithText(TextButton, "Delete");
+      final scrollableFinder = find.byType(Scrollable).last;
+      await tester.scrollUntilVisible(buttonFinder, 10,
+          scrollable: scrollableFinder);
+      await tester.tap(buttonFinder);
+      await tester.pumpAndSettle();
+
+      expect(find.text("Delete This Statement?"), findsOneWidget);
+      expect(find.text("Are you sure you want to delete this statement?"),
+          findsOneWidget);
+    });
+
+    testWidgets('tapping no dismissess the warning prompt', (tester) async {
+      int pensionId = 1;
+      String name = "Test Pension";
+      DateTime maturityDate = DateHelper.getToday();
+      int statementId = 1;
+      DateTime statementDate = DateHelper.getToday();
+      double planValue = 12345.0;
+      double projectedAnnualAmount = 1234;
+      double yearlyCharges = 100;
+      double transferValue = 12345;
+
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllPensions()).thenAnswer((_) async => [
+            Pension(
+                pensionId: pensionId, name: name, maturityDate: maturityDate)
+          ]);
+      when(databaseService.deleteStatement(statementId))
+          .thenAnswer((_) async => statementId);
+
+      final statement = Statement(
+          statementId: statementId,
+          pension: pensionId,
+          statementDate: statementDate,
+          planValue: planValue,
+          projectedAnnualAmount: projectedAnnualAmount,
+          yearlyCharges: yearlyCharges,
+          transferValue: transferValue);
+      await tester.pumpWidget(createEditScreen(statement, databaseService));
+      await tester.pumpAndSettle();
+
+      // Tap the delete button (scroll to it first as it may be off screen)
+      final buttonFinder = find.widgetWithText(TextButton, "Delete");
+      final scrollableFinder = find.byType(Scrollable).last;
+      await tester.scrollUntilVisible(buttonFinder, 10,
+          scrollable: scrollableFinder);
+      await tester.tap(buttonFinder);
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, "No"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Delete This Statement?"), findsNothing);
+      expect(find.text("Are you sure you want to delete this statement?"),
+          findsNothing);
+
+      verifyNever(databaseService.deleteStatement(statementId));
+    });
+
+    testWidgets(
+        'tapping yes deletes the statement and dismissess the warning prompt',
+        (tester) async {
+      int pensionId = 1;
+      String name = "Test Pension";
+      DateTime maturityDate = DateHelper.getToday();
+      int statementId = 5;
+      DateTime statementDate = DateHelper.getToday();
+      double planValue = 12345.0;
+      double projectedAnnualAmount = 1234;
+      double yearlyCharges = 100;
+      double transferValue = 12345;
+
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllPensions()).thenAnswer((_) async => [
+            Pension(
+                pensionId: pensionId, name: name, maturityDate: maturityDate)
+          ]);
+      when(databaseService.deleteStatement(statementId))
+          .thenAnswer((_) async => statementId);
+
+      final statement = Statement(
+          statementId: statementId,
+          pension: pensionId,
+          statementDate: statementDate,
+          planValue: planValue,
+          projectedAnnualAmount: projectedAnnualAmount,
+          yearlyCharges: yearlyCharges,
+          transferValue: transferValue);
+      await tester.pumpWidget(createEditScreen(statement, databaseService));
+      await tester.pumpAndSettle();
+
+      // Tap the delete button (scroll to it first as it may be off screen)
+      final buttonFinder = find.widgetWithText(TextButton, "Delete");
+      final scrollableFinder = find.byType(Scrollable).last;
+      await tester.scrollUntilVisible(buttonFinder, 10,
+          scrollable: scrollableFinder);
+      await tester.tap(buttonFinder);
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, "Yes"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Delete This Statement?"), findsNothing);
+      expect(find.text("Are you sure you want to delete this statement?"),
+          findsNothing);
+      expect(find.widgetWithText(SnackBar, "Statement removed successfully!"),
+          findsOneWidget); //look for snackbar notification
+
+      verify(databaseService.deleteStatement(statementId)).called(1);
+    });
+
     // test cancel
   });
 }

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -312,8 +312,8 @@ void main() {
       final databaseService = MockDatabaseService();
       when(databaseService.clearAllData()).thenAnswer((_) async => true);
 
-      await tester.pumpWidget(
-          createSettingsScreen(settingsService, MockDatabaseService()));
+      await tester
+          .pumpWidget(createSettingsScreen(settingsService, databaseService));
       await tester.pumpAndSettle();
 
       // Tap the delete button


### PR DESCRIPTION
Added a delete button to the Edit Pension and Edit statement screens

Resolves #15 