### PR TITLE
feat: add link to state pension screen

### DIFF
--- a/lib/screens/edit_state_pension_screen.dart
+++ b/lib/screens/edit_state_pension_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:pension_compare/constants/custom_styles.dart';
 import 'package:pension_compare/database/database_service.dart';
 import 'package:pension_compare/helpers/currency_helper.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class EditStatePensionScreen extends StatefulWidget {
   static const yearlyValueKey = Key('yearlyValue');
@@ -17,6 +18,8 @@ class EditStatePensionScreen extends StatefulWidget {
 
 class _EditStatePensionScreenState extends State<EditStatePensionScreen> {
   TextEditingController yearlyValueController = TextEditingController();
+  final govUkStatePensionWebSiteUrl =
+      Uri(scheme: 'https', host: 'gov.uk', path: 'check-state-pension');
 
   bool _unsavedChanges = false;
   final _formKey = GlobalKey<FormState>();
@@ -136,7 +139,12 @@ class _EditStatePensionScreenState extends State<EditStatePensionScreen> {
                   const Text(
                       "This is the yearly value you will receive from your state pension.  If you don't know this you can find the amount here:",
                       style: CustomStyles.infoTextStyle),
-                  const Text('gov.uk/check-state-pension'),
+                  CustomStyles.spacerBox,
+                  ElevatedButton(
+                    onPressed: () =>
+                        _launchInBrowser(govUkStatePensionWebSiteUrl),
+                    child: const Text('gov.uk/check-state-pension'),
+                  ),
                 ],
               ),
             ),
@@ -195,6 +203,18 @@ class _EditStatePensionScreenState extends State<EditStatePensionScreen> {
     if (shouldDiscard ?? false) {
       if (!mounted) return;
       Navigator.of(context).pop();
+    }
+  }
+
+  Future<void> _launchInBrowser(Uri url) async {
+    if (!await launchUrl(
+      url,
+      mode: LaunchMode.externalApplication,
+    )) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+        content: Text('Unable to launch website'),
+      ));
     }
   }
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <sqlcipher_flutter_libs/sqlite3_flutter_libs_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) sqlcipher_flutter_libs_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
   sqlite3_flutter_libs_plugin_register_with_registrar(sqlcipher_flutter_libs_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   sqlcipher_flutter_libs
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,11 @@ import Foundation
 import path_provider_foundation
 import shared_preferences_foundation
 import sqlcipher_flutter_libs
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -561,7 +561,7 @@ packages:
     source: hosted
     version: "3.1.4"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
@@ -837,6 +837,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "0ecc004c62fd3ed36a2ffcbe0dd9700aee63bd7532d0b642a488b1ec310f492e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.5"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "9149d493b075ed740901f3ee844a38a00b33116c7c5c10d7fb27df8987fb51d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.5"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  url_launcher_platform_interface:
+    dependency: "direct dev"
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "3692a459204a33e04bc94f5fb91158faf4f2c8903281ddd82915adecdb1a901d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   http: ^1.2.1
   intl: ^0.19.0
   fl_chart: ^0.66.2
+  url_launcher: ^6.2.5
   
 dev_dependencies:
   flutter_test:
@@ -64,6 +65,8 @@ dev_dependencies:
   json_serializable: ^6.7.1
   mockito: ^5.4.4
   matcher: ^0.12.16+1
+  plugin_platform_interface: ^2.1.8
+  url_launcher_platform_interface: ^2.3.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/mocks/mock_url_launcher.dart
+++ b/test/mocks/mock_url_launcher.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+class MockUrlLauncher extends Fake
+    with MockPlatformInterfaceMixin
+    implements UrlLauncherPlatform {
+  int launchModeCallCount = 0;
+  bool launchUrlReturnValue = true;
+
+  void setLaunchUrlExpectation(bool returnValue) {
+    launchUrlReturnValue = returnValue;
+  }
+
+  Future<bool> launchUrl(String url, LaunchOptions options) {
+    launchModeCallCount++;
+    return Future.value(launchUrlReturnValue);
+  }
+
+  int launchUrlCalledCount() {
+    return launchModeCallCount;
+  }
+}

--- a/test/screens/edit_state_pension_screen_test.dart
+++ b/test/screens/edit_state_pension_screen_test.dart
@@ -5,7 +5,8 @@ import 'package:pension_compare/database/database_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:pension_compare/constants/defaults.dart' as defaults;
-
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+import '../mocks/mock_url_launcher.dart';
 import 'edit_state_pension_screen_test.mocks.dart';
 
 Widget createEditScreen(DatabaseService? db) {
@@ -129,6 +130,52 @@ void main() {
           find.text("Please enter a value, or 0 if unknown"), findsOneWidget);
 
       verifyNever(databaseService.saveStatePension(0));
+    });
+  });
+
+  group('Test url launcher to state pension site', () {
+    testWidgets('test url launcher is successful', (tester) async {
+      final MockUrlLauncher mock = MockUrlLauncher();
+      mock.setLaunchUrlExpectation(true);
+      UrlLauncherPlatform.instance = mock;
+
+      final databaseService = MockDatabaseService();
+      when(databaseService.getStatePension()).thenAnswer((_) async =>
+          const StatePension(
+              statePensionId: defaults.defaultStatePensionId,
+              projectedAnnualAmount: 1));
+
+      await tester.pumpWidget(createEditScreen(databaseService));
+      await tester.pumpAndSettle();
+
+      expect(find.text("gov.uk/check-state-pension"), findsOneWidget);
+      await tester.tap(
+          find.widgetWithText(ElevatedButton, "gov.uk/check-state-pension"));
+
+      expect(mock.launchUrlCalledCount(), 1);
+    });
+
+    testWidgets('test url launcher fails', (tester) async {
+      final MockUrlLauncher mock = MockUrlLauncher();
+      mock.setLaunchUrlExpectation(false);
+      UrlLauncherPlatform.instance = mock;
+
+      final databaseService = MockDatabaseService();
+      when(databaseService.getStatePension()).thenAnswer((_) async =>
+          const StatePension(
+              statePensionId: defaults.defaultStatePensionId,
+              projectedAnnualAmount: 1));
+
+      await tester.pumpWidget(createEditScreen(databaseService));
+      await tester.pumpAndSettle();
+
+      expect(find.text("gov.uk/check-state-pension"), findsOneWidget);
+      await tester.tap(
+          find.widgetWithText(ElevatedButton, "gov.uk/check-state-pension"));
+      await tester.pumpAndSettle();
+
+      expect(mock.launchUrlCalledCount(), 1);
+      expect(find.text("Unable to launch website"), findsOneWidget);
     });
   });
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <sqlcipher_flutter_libs/sqlite3_flutter_libs_plugin.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   Sqlite3FlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   sqlcipher_flutter_libs
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
The link to the gov.uk website is now a link.  Tapping opens in the platforms default browser.  Uses [url_launcher](https://pub.dev/packages/url_launcher) plugin