### PR TITLE
feat: add validation to prevent duplicate statement date

### DIFF
--- a/lib/database/database_service.dart
+++ b/lib/database/database_service.dart
@@ -6,6 +6,7 @@ import 'package:pension_compare/database/tables/statement.dart';
 import 'package:pension_compare/database/tables/state_pension.dart';
 import 'package:pension_compare/database/tables/pensions_with_latest_statement.dart';
 import 'package:pension_compare/constants/defaults.dart' as defaults;
+import 'package:pension_compare/helpers/date_helper.dart';
 
 part 'database_service.g.dart';
 
@@ -52,14 +53,16 @@ class DatabaseService extends _$DatabaseService {
 
   // Create a new pension record
   Future<Pension?> createPension(String name, DateTime maturityDate) {
-    return into(pensions).insertReturningOrNull(
-        PensionsCompanion.insert(name: name, maturityDate: maturityDate));
+    return into(pensions).insertReturningOrNull(PensionsCompanion.insert(
+        name: name, maturityDate: DateHelper.removeTime(maturityDate)));
   }
 
   // Update an existing pension record, return true if successful
   Future<bool> updatePension(int id, String name, DateTime maturityDate) {
-    return update(pensions).replace(
-        Pension(pensionId: id, name: name, maturityDate: maturityDate));
+    return update(pensions).replace(Pension(
+        pensionId: id,
+        name: name,
+        maturityDate: DateHelper.removeTime(maturityDate)));
   }
 
   // Delete a pension record by its id and return the number of records deleted
@@ -102,7 +105,7 @@ class DatabaseService extends _$DatabaseService {
       double? transferValue) {
     return into(statements).insertReturningOrNull(StatementsCompanion.insert(
         pension: pensionId,
-        statementDate: statementDate,
+        statementDate: DateHelper.removeTime(statementDate),
         planValue: planValue,
         projectedAnnualAmount: projectedAnnualAmount,
         yearlyCharges: Value(yearlyCharges),
@@ -121,7 +124,7 @@ class DatabaseService extends _$DatabaseService {
     return update(statements).replace(Statement(
         statementId: id,
         pension: pensionId,
-        statementDate: statementDate,
+        statementDate: DateHelper.removeTime(statementDate),
         planValue: planValue,
         projectedAnnualAmount: projectedAnnualAmount,
         yearlyCharges: yearlyCharges,
@@ -131,6 +134,21 @@ class DatabaseService extends _$DatabaseService {
   // Delete a statement record by its id and return the number of records deleted
   Future<int> deleteStatement(int id) {
     return (delete(statements)..where((s) => s.statementId.equals(id))).go();
+  }
+
+  // Checks to see if a statement date already exists in the database for this pension,
+  // but with a different id
+  Future<bool> doesStatementDateExist(
+      int? id, int pensionId, DateTime statementDate) async {
+    final pension = await (select(statements)
+          ..where((s) =>
+              s.pension.equals(pensionId) &
+              s.statementId.equals(id ?? 0).not() &
+              s.statementDate.equals(DateHelper.removeTime(statementDate)))
+          ..limit(1))
+        .getSingleOrNull();
+
+    return (pension != null);
   }
 
   // Get the state pension record.  There should only be one record in the table

--- a/lib/database/database_service.g.dart
+++ b/lib/database/database_service.g.dart
@@ -348,6 +348,10 @@ class $StatementsTable extends Statements
   @override
   Set<GeneratedColumn> get $primaryKey => {statementId};
   @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+        {pension, statementDate},
+      ];
+  @override
   Statement map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return Statement(

--- a/lib/database/tables/statement.dart
+++ b/lib/database/tables/statement.dart
@@ -14,4 +14,9 @@ class Statements extends Table {
   RealColumn get projectedAnnualAmount => real()();
   RealColumn get yearlyCharges => real().nullable()();
   RealColumn get transferValue => real().nullable()();
+
+  @override
+  List<Set<Column>> get uniqueKeys => [
+        {pension, statementDate}
+      ];
 }

--- a/lib/helpers/date_helper.dart
+++ b/lib/helpers/date_helper.dart
@@ -16,4 +16,9 @@ class DateHelper {
     DateTime now = DateTime.now();
     return DateTime(now.year, now.month, now.day);
   }
+
+  // Remove the time component from the dateTime object
+  static DateTime removeTime(DateTime dateTime) {
+    return DateTime(dateTime.year, dateTime.month, dateTime.day);
+  }
 }

--- a/lib/screens/edit_statement_screen.dart
+++ b/lib/screens/edit_statement_screen.dart
@@ -41,6 +41,7 @@ class _EditStatmentScreenState extends State<EditStatementScreen> {
   TextEditingController transferValueController = TextEditingController();
   DateTime? _statementDate;
   int? _pensionId;
+  String? _statementDateValidationError;
   Future<List<Pension>>? _pensions;
 
   bool _unsavedChanges = false;
@@ -86,15 +87,17 @@ class _EditStatmentScreenState extends State<EditStatementScreen> {
                       color: context.onPrimary,
                     )),
                 onPressed: () async {
-                  if (_formKey.currentState!.validate()) {
-                    if (!await _saveData()) {
-                      // an error occurred and we cannot save?
-                      // TODO Log and report error
-                      return;
-                    }
+                  if (await _validateStatementDate(_statementDate)) {
+                    if (_formKey.currentState!.validate()) {
+                      if (!await _saveData()) {
+                        // an error occurred and we cannot save?
+                        // TODO Log and report error
+                        return;
+                      }
 
-                    if (!context.mounted) return;
-                    Navigator.of(context).pop();
+                      if (!context.mounted) return;
+                      Navigator.of(context).pop();
+                    }
                   }
                 },
               ),
@@ -141,7 +144,9 @@ class _EditStatmentScreenState extends State<EditStatementScreen> {
                     key: EditStatementScreen.statementDateKey,
                     initialDate: _statementDate,
                     labelText: 'Statement Date',
+                    errorText: _statementDateValidationError,
                     onDateSelected: (DateTime? value) {
+                      _statementDateValidationError = null;
                       _statementDate = value;
                       _unsavedChanges = true;
                     },
@@ -256,6 +261,25 @@ class _EditStatmentScreenState extends State<EditStatementScreen> {
             ),
           ),
         ));
+  }
+
+  Future<bool> _validateStatementDate(DateTime? statementDate) async {
+    String? validationMsg;
+
+    if (statementDate != null && _pensionId != null) {
+      bool response = await widget.databaseService.doesStatementDateExist(
+          widget.statement?.statementId, _pensionId!, statementDate);
+
+      if (response) {
+        validationMsg = "A statement for this date already exists";
+      }
+    }
+
+    setState(() {
+      _statementDateValidationError = validationMsg;
+    });
+
+    return (validationMsg == null);
   }
 
   void _loadData() {

--- a/lib/widgets/date_field.dart
+++ b/lib/widgets/date_field.dart
@@ -3,6 +3,7 @@ import 'package:pension_compare/helpers/date_helper.dart';
 
 class DateField extends StatelessWidget {
   final String? labelText;
+  final String? errorText;
   final DateTime? initialDate;
   final Function(DateTime?)? onDateSelected;
   final String? Function(DateTime?)? onValidate;
@@ -12,6 +13,7 @@ class DateField extends StatelessWidget {
       {super.key,
       this.initialDate,
       this.labelText,
+      this.errorText,
       this.onDateSelected,
       this.onValidate});
 
@@ -24,7 +26,8 @@ class DateField extends StatelessWidget {
       controller: fieldController,
       decoration: InputDecoration(
           icon: const Icon(Icons.calendar_today), //icon of text field
-          labelText: labelText),
+          labelText: labelText,
+          errorText: errorText),
       readOnly: true, // when true user cannot edit text
       onTap: () async {
         DateTime? pickedDate = await showDatePicker(

--- a/test/database/database_service_statement_test.dart
+++ b/test/database/database_service_statement_test.dart
@@ -94,6 +94,48 @@ void main() {
       expect(result.transferValue, transferValue);
     });
 
+    test(
+        'Saving a new statement object removes time component from statement date',
+        () async {
+      DateTime statementDate = DateTime(2024, 2, 3, 12, 34, 56, 78);
+      double planValue = 123.45;
+      double projectedAnnualAmount = 456.78;
+      double? yearlyCharges = 78.90;
+      double? transferValue = 90.12;
+
+      final pension =
+          await database.createPension('pension', DateTime(2050, 1, 1));
+
+      final entry = await database.createStatement(
+          pension!.pensionId,
+          statementDate,
+          planValue,
+          projectedAnnualAmount,
+          yearlyCharges,
+          transferValue);
+
+      expect(entry, match.isNotNull);
+      expect(entry!.statementDate.year, statementDate.year);
+      expect(entry.statementDate.month, statementDate.month);
+      expect(entry.statementDate.day, statementDate.day);
+      expect(entry.statementDate.hour, 0);
+      expect(entry.statementDate.minute, 0);
+      expect(entry.statementDate.second, 0);
+      expect(entry.statementDate.millisecond, 0);
+      expect(entry.statementDate.microsecond, 0);
+
+      final result = await database.getStatement(entry.statementId);
+      expect(result, match.isNotNull);
+      expect(result!.statementDate.year, statementDate.year);
+      expect(result.statementDate.month, statementDate.month);
+      expect(result.statementDate.day, statementDate.day);
+      expect(result.statementDate.hour, 0);
+      expect(result.statementDate.minute, 0);
+      expect(result.statementDate.second, 0);
+      expect(result.statementDate.millisecond, 0);
+      expect(result.statementDate.microsecond, 0);
+    });
+
     test('read all new statement objects', () async {
       DateTime statementDate1 = DateTime(2024, 2, 3);
       double planValue1 = 123.45;
@@ -239,7 +281,8 @@ void main() {
     });
 
     test('delete a pension also deletes all statement objects', () async {
-      DateTime statementDate = DateTime(2024, 2, 3);
+      DateTime statementDate1 = DateTime(2023, 1, 1);
+      DateTime statementDate2 = DateTime(2024, 1, 1);
       double planValue = 123.45;
       double projectedAnnualAmount = 456.78;
       double? yearlyCharges = 78.90;
@@ -248,9 +291,9 @@ void main() {
       final pension =
           await database.createPension('pension', DateTime(2050, 1, 1));
 
-      await database.createStatement(pension!.pensionId, statementDate,
+      await database.createStatement(pension!.pensionId, statementDate1,
           planValue, projectedAnnualAmount, yearlyCharges, transferValue);
-      await database.createStatement(pension.pensionId, statementDate,
+      await database.createStatement(pension.pensionId, statementDate2,
           planValue, projectedAnnualAmount, yearlyCharges, transferValue);
 
       final results =
@@ -265,6 +308,197 @@ void main() {
           await database.getAllStatementsForPension(pension.pensionId);
       expect(resultsAfterDelete, match.isNotNull);
       expect(resultsAfterDelete.length, 0);
+    });
+  });
+
+  group('Test pension / statement date combination is unique', () {
+    test('Create fails if statement date already in use', () async {
+      DateTime statementDate = DateTime(2024, 2, 3);
+      double planValue = 123.45;
+      double projectedAnnualAmount = 456.78;
+      double? yearlyCharges = 78.90;
+      double? transferValue = 90.12;
+
+      final pension =
+          await database.createPension('pension', DateTime(2050, 1, 1));
+
+      await database.createStatement(pension!.pensionId, statementDate,
+          planValue, projectedAnnualAmount, yearlyCharges, transferValue);
+      await expectLater(
+          database.createStatement(pension.pensionId, statementDate, planValue,
+              projectedAnnualAmount, yearlyCharges, transferValue),
+          throwsA(isException));
+    });
+
+    test('Create succeeds if statement date already in use but record deleted',
+        () async {
+      DateTime statementDate = DateTime(2024, 2, 3);
+      double planValue = 123.45;
+      double projectedAnnualAmount = 456.78;
+      double? yearlyCharges = 78.90;
+      double? transferValue = 90.12;
+
+      final pension =
+          await database.createPension('pension', DateTime(2050, 1, 1));
+
+      Statement? s1 = await database.createStatement(
+          pension!.pensionId,
+          statementDate,
+          planValue,
+          projectedAnnualAmount,
+          yearlyCharges,
+          transferValue);
+      await database.deleteStatement(s1!.statementId);
+      await expectLater(
+          database.createStatement(pension.pensionId, statementDate, planValue,
+              projectedAnnualAmount, yearlyCharges, transferValue),
+          completes);
+    });
+
+    test('Create succeeds if statement date already in use on another pension',
+        () async {
+      DateTime statementDate = DateTime(2024, 2, 3);
+      double planValue = 123.45;
+      double projectedAnnualAmount = 456.78;
+      double? yearlyCharges = 78.90;
+      double? transferValue = 90.12;
+
+      final pension1 =
+          await database.createPension('pension 1', DateTime(2050, 1, 1));
+      final pension2 =
+          await database.createPension('pension 2', DateTime(2050, 1, 1));
+      await database.createStatement(pension1!.pensionId, statementDate,
+          planValue, projectedAnnualAmount, yearlyCharges, transferValue);
+      await expectLater(
+          database.createStatement(pension2!.pensionId, statementDate,
+              planValue, projectedAnnualAmount, yearlyCharges, transferValue),
+          completes);
+    });
+
+    test('Test if statement date already used in an empty table', () async {
+      int pensionId = 1;
+      DateTime statementDate = DateTime(2024, 2, 3);
+
+      bool response =
+          await database.doesStatementDateExist(null, pensionId, statementDate);
+
+      expect(response, isFalse);
+    });
+
+    test('Test if statement date already used in populated table', () async {
+      DateTime statementDate = DateTime(2024, 2, 3);
+      double planValue = 123.45;
+      double projectedAnnualAmount = 456.78;
+      double? yearlyCharges = 78.90;
+      double? transferValue = 90.12;
+
+      final pension1 =
+          await database.createPension('pension 1', DateTime(2050, 1, 1));
+      await database.createStatement(pension1!.pensionId, statementDate,
+          planValue, projectedAnnualAmount, yearlyCharges, transferValue);
+
+      bool response = await database.doesStatementDateExist(
+          null, pension1.pensionId, statementDate);
+
+      expect(response, isTrue);
+    });
+
+    test('Test if statement date already used for this record', () async {
+      DateTime statementDate = DateTime(2024, 2, 3);
+      double planValue = 123.45;
+      double projectedAnnualAmount = 456.78;
+      double? yearlyCharges = 78.90;
+      double? transferValue = 90.12;
+
+      final pension1 =
+          await database.createPension('pension 1', DateTime(2050, 1, 1));
+      final statement1 = await database.createStatement(
+          pension1!.pensionId,
+          statementDate,
+          planValue,
+          projectedAnnualAmount,
+          yearlyCharges,
+          transferValue);
+
+      bool response = await database.doesStatementDateExist(
+          statement1!.statementId, pension1.pensionId, statementDate);
+
+      expect(response, isFalse);
+    });
+
+    test('Test if statement date already used for another record', () async {
+      DateTime statementDate1 = DateTime(2023, 1, 1);
+      DateTime statementDate2 = DateTime(2024, 1, 1);
+      DateTime statementDate2Updated = DateTime(2023, 1, 1);
+      double planValue = 123.45;
+      double projectedAnnualAmount = 456.78;
+      double? yearlyCharges = 78.90;
+      double? transferValue = 90.12;
+
+      Pension? pension1 =
+          await database.createPension('pension 1', DateTime(2050, 1, 1));
+      await database.createStatement(pension1!.pensionId, statementDate1,
+          planValue, projectedAnnualAmount, yearlyCharges, transferValue);
+      final statement2 = await database.createStatement(
+          pension1.pensionId,
+          statementDate2,
+          planValue,
+          projectedAnnualAmount,
+          yearlyCharges,
+          transferValue);
+
+      bool response = await database.doesStatementDateExist(
+          statement2!.statementId, pension1.pensionId, statementDate2Updated);
+
+      expect(response, isTrue);
+    });
+
+    test('Test if statement date is already used with deleted record',
+        () async {
+      DateTime statementDate = DateTime(2024, 2, 3);
+      double planValue = 123.45;
+      double projectedAnnualAmount = 456.78;
+      double? yearlyCharges = 78.90;
+      double? transferValue = 90.12;
+
+      final pension =
+          await database.createPension('pension', DateTime(2050, 1, 1));
+
+      Statement? s1 = await database.createStatement(
+          pension!.pensionId,
+          statementDate,
+          planValue,
+          projectedAnnualAmount,
+          yearlyCharges,
+          transferValue);
+      await database.deleteStatement(s1!.statementId);
+
+      bool response = await database.doesStatementDateExist(
+          null, pension.pensionId, statementDate);
+
+      expect(response, isFalse);
+    });
+
+    test(
+        'Test the time component is ignored when checking statement date exists',
+        () async {
+      DateTime statementDate = DateTime(2024, 2, 3, 12, 34, 56, 78);
+      DateTime statementDate2 = DateTime(2024, 2, 3, 18, 23, 45, 67);
+      double planValue = 123.45;
+      double projectedAnnualAmount = 456.78;
+      double? yearlyCharges = 78.90;
+      double? transferValue = 90.12;
+
+      final pension =
+          await database.createPension('pension', DateTime(2050, 1, 1));
+
+      await database.createStatement(pension!.pensionId, statementDate,
+          planValue, projectedAnnualAmount, yearlyCharges, transferValue);
+
+      bool response = await database.doesStatementDateExist(
+          null, pension.pensionId, statementDate2);
+
+      expect(response, isTrue);
     });
   });
 }

--- a/test/database/database_service_test.dart
+++ b/test/database/database_service_test.dart
@@ -19,11 +19,11 @@ void main() {
     test('running cleardown removes all pensions and statements', () async {
       final pension =
           await database.createPension('test pension', DateHelper.getToday());
-      await database.createStatement(pension!.pensionId, DateHelper.getToday(),
+      await database.createStatement(pension!.pensionId, DateTime(2021, 1, 1),
           1000.0, 2000.0, 3000.0, 4000.0);
-      await database.createStatement(pension.pensionId, DateHelper.getToday(),
+      await database.createStatement(pension.pensionId, DateTime(2022, 1, 1),
           1000.0, 2000.0, 3000.0, 4000.0);
-      await database.createStatement(pension.pensionId, DateHelper.getToday(),
+      await database.createStatement(pension.pensionId, DateTime(2023, 1, 1),
           1000.0, 2000.0, 3000.0, 4000.0);
       await database.saveStatePension(12345.0);
 

--- a/test/helpers/date_helper_test.dart
+++ b/test/helpers/date_helper_test.dart
@@ -48,4 +48,38 @@ void main() {
       expect(parsedDate, isNull);
     });
   });
+
+  group('Test removing time component', () {
+    test('Test the time removal', () {
+      DateTime dateToParse = DateTime(2024, 1, 1, 12, 30, 45);
+
+      DateTime parsedDate = DateHelper.removeTime(dateToParse);
+
+      expect(parsedDate.year, 2024);
+      expect(parsedDate.month, 1);
+      expect(parsedDate.day, 1);
+
+      expect(parsedDate.hour, 0);
+      expect(parsedDate.minute, 0);
+      expect(parsedDate.second, 0);
+      expect(parsedDate.millisecond, 0);
+      expect(parsedDate.microsecond, 0);
+    });
+
+    test('Test the time removal when no time specified', () {
+      DateTime dateToParse = DateTime(2024, 1, 1);
+
+      DateTime parsedDate = DateHelper.removeTime(dateToParse);
+
+      expect(parsedDate.year, 2024);
+      expect(parsedDate.month, 1);
+      expect(parsedDate.day, 1);
+
+      expect(parsedDate.hour, 0);
+      expect(parsedDate.minute, 0);
+      expect(parsedDate.second, 0);
+      expect(parsedDate.millisecond, 0);
+      expect(parsedDate.microsecond, 0);
+    });
+  });
 }

--- a/test/screens/edit_pension_screen_test.mocks.dart
+++ b/test/screens/edit_pension_screen_test.mocks.dart
@@ -552,6 +552,24 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<int>);
 
   @override
+  _i5.Future<bool> doesStatementDateExist(
+    int? id,
+    int? pensionId,
+    DateTime? statementDate,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #doesStatementDateExist,
+          [
+            id,
+            pensionId,
+            statementDate,
+          ],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
   _i5.Future<_i3.StatePension?> getStatePension() => (super.noSuchMethod(
         Invocation.method(
           #getStatePension,

--- a/test/screens/edit_state_pension_screen_test.mocks.dart
+++ b/test/screens/edit_state_pension_screen_test.mocks.dart
@@ -552,6 +552,24 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<int>);
 
   @override
+  _i5.Future<bool> doesStatementDateExist(
+    int? id,
+    int? pensionId,
+    DateTime? statementDate,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #doesStatementDateExist,
+          [
+            id,
+            pensionId,
+            statementDate,
+          ],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
   _i5.Future<_i3.StatePension?> getStatePension() => (super.noSuchMethod(
         Invocation.method(
           #getStatePension,

--- a/test/screens/edit_statement_screen_test.dart
+++ b/test/screens/edit_statement_screen_test.dart
@@ -125,6 +125,9 @@ void main() {
               projectedAnnualAmount: projectedAnnualAmount,
               yearlyCharges: yearlyCharges,
               transferValue: transferValue));
+      when(databaseService.doesStatementDateExist(
+              null, pensionId, statementDate))
+          .thenAnswer((_) async => false);
 
       await tester.pumpWidget(createEditScreen(null, databaseService));
       await tester.pumpAndSettle();
@@ -191,6 +194,9 @@ void main() {
               newYearlyCharges,
               newTransferValue))
           .thenAnswer((_) async => true);
+      when(databaseService.doesStatementDateExist(
+              statementId, pensionId, newStatementDate))
+          .thenAnswer((_) async => false);
 
       await tester.pumpWidget(createEditScreen(
           Statement(
@@ -270,6 +276,9 @@ void main() {
               projectedAnnualAmount: projectedAnnualAmount,
               yearlyCharges: yearlyCharges,
               transferValue: transferValue));
+      when(databaseService.doesStatementDateExist(
+              null, pensionId, statementDate))
+          .thenAnswer((_) async => false);
 
       await tester.pumpWidget(createEditScreen(null, databaseService));
       await tester.pumpAndSettle();
@@ -306,6 +315,161 @@ void main() {
       verify(databaseService.getAllPensions()).called(1);
       verifyNever(databaseService.createStatement(pensionId, statementDate,
           planValue, projectedAnnualAmount, yearlyCharges, transferValue));
+    });
+
+    testWidgets('validation should warn of duplicate statement date',
+        (tester) async {
+      String name = "Test Pension";
+      DateTime maturityDate = DateHelper.getToday();
+      int pensionId = 1;
+      DateTime statementDate = DateHelper.getToday();
+      double planValue = 12345.0;
+      double projectedAnnualAmount = 1234;
+      double yearlyCharges = 100;
+      double transferValue = 12345;
+
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllPensions()).thenAnswer((_) async => [
+            Pension(
+                pensionId: pensionId, name: name, maturityDate: maturityDate)
+          ]);
+      when(databaseService.createStatement(pensionId, statementDate, planValue,
+              projectedAnnualAmount, yearlyCharges, transferValue))
+          .thenAnswer((_) async => Statement(
+              statementId: 1,
+              pension: pensionId,
+              statementDate: statementDate,
+              planValue: planValue,
+              projectedAnnualAmount: projectedAnnualAmount,
+              yearlyCharges: yearlyCharges,
+              transferValue: transferValue));
+      when(databaseService.doesStatementDateExist(
+              null, pensionId, statementDate))
+          .thenAnswer((_) async => true);
+
+      await tester.pumpWidget(createEditScreen(null, databaseService));
+      await tester.pumpAndSettle();
+
+      // select the pension from the DropDownButtonFormField
+      await tester.tap(find.byKey(EditStatementScreen.pensionKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(DropdownMenuItem<int>, name).last);
+      await tester.pumpAndSettle();
+
+      // Set the date of the date picker
+      await tester.tap(find.byKey(EditStatementScreen.statementDateKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(statementDate.day.toString()));
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.byKey(EditStatementScreen.planValueKey), planValue.toString());
+      await tester.enterText(
+          find.byKey(EditStatementScreen.projectedAnnualAmountKey),
+          projectedAnnualAmount.toString());
+      await tester.enterText(find.byKey(EditStatementScreen.yearlyChargesKey),
+          yearlyCharges.toString());
+      await tester.enterText(find.byKey(EditStatementScreen.transferValueKey),
+          transferValue.toString());
+
+      // Tap the save button
+      await tester.tap(find.widgetWithText(TextButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text("A statement for this date already exists"),
+          findsOneWidget);
+
+      verify(databaseService.getAllPensions()).called(1);
+      verify(databaseService.doesStatementDateExist(
+              null, pensionId, statementDate))
+          .called(1);
+      verifyNever(databaseService.createStatement(pensionId, statementDate,
+          planValue, projectedAnnualAmount, yearlyCharges, transferValue));
+    });
+
+    testWidgets('validation should clear after duplicate pension name',
+        (tester) async {
+      String name = "Test Pension";
+      DateTime maturityDate = DateHelper.getToday();
+      int pensionId = 1;
+      DateTime statementDate = DateHelper.getToday();
+      DateTime newStatementDate = DateTime(
+          statementDate.year,
+          statementDate.month,
+          (statementDate.day == 1 ? 2 : 1)); // different date
+      double planValue = 12345.0;
+      double projectedAnnualAmount = 1234;
+      double yearlyCharges = 100;
+      double transferValue = 12345;
+
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllPensions()).thenAnswer((_) async => [
+            Pension(
+                pensionId: pensionId, name: name, maturityDate: maturityDate)
+          ]);
+      when(databaseService.createStatement(pensionId, newStatementDate,
+              planValue, projectedAnnualAmount, yearlyCharges, transferValue))
+          .thenAnswer((_) async => Statement(
+              statementId: 1,
+              pension: pensionId,
+              statementDate: statementDate,
+              planValue: planValue,
+              projectedAnnualAmount: projectedAnnualAmount,
+              yearlyCharges: yearlyCharges,
+              transferValue: transferValue));
+      when(databaseService.doesStatementDateExist(
+              null, pensionId, statementDate))
+          .thenAnswer((_) async => true);
+      when(databaseService.doesStatementDateExist(
+              null, pensionId, newStatementDate))
+          .thenAnswer((_) async => false);
+
+      await tester.pumpWidget(createEditScreen(null, databaseService));
+      await tester.pumpAndSettle();
+
+      // select the pension from the DropDownButtonFormField
+      await tester.tap(find.byKey(EditStatementScreen.pensionKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(DropdownMenuItem<int>, name).last);
+      await tester.pumpAndSettle();
+
+      // Set the date of the date picker
+      await tester.tap(find.byKey(EditStatementScreen.statementDateKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(statementDate.day.toString()));
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.byKey(EditStatementScreen.planValueKey), planValue.toString());
+      await tester.enterText(
+          find.byKey(EditStatementScreen.projectedAnnualAmountKey),
+          projectedAnnualAmount.toString());
+      await tester.enterText(find.byKey(EditStatementScreen.yearlyChargesKey),
+          yearlyCharges.toString());
+      await tester.enterText(find.byKey(EditStatementScreen.transferValueKey),
+          transferValue.toString());
+
+      // Tap the save button
+      await tester.tap(find.widgetWithText(TextButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text("A statement for this date already exists"),
+          findsOneWidget);
+
+      // change the date
+      await tester.tap(find.byKey(EditStatementScreen.statementDateKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(newStatementDate.day.toString()));
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text("A statement for this date already exists"), findsNothing);
     });
   });
 

--- a/test/screens/edit_statement_screen_test.mocks.dart
+++ b/test/screens/edit_statement_screen_test.mocks.dart
@@ -552,6 +552,24 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<int>);
 
   @override
+  _i5.Future<bool> doesStatementDateExist(
+    int? id,
+    int? pensionId,
+    DateTime? statementDate,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #doesStatementDateExist,
+          [
+            id,
+            pensionId,
+            statementDate,
+          ],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
   _i5.Future<_i3.StatePension?> getStatePension() => (super.noSuchMethod(
         Invocation.method(
           #getStatePension,

--- a/test/screens/home_screen_test.mocks.dart
+++ b/test/screens/home_screen_test.mocks.dart
@@ -552,6 +552,24 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<int>);
 
   @override
+  _i5.Future<bool> doesStatementDateExist(
+    int? id,
+    int? pensionId,
+    DateTime? statementDate,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #doesStatementDateExist,
+          [
+            id,
+            pensionId,
+            statementDate,
+          ],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
   _i5.Future<_i3.StatePension?> getStatePension() => (super.noSuchMethod(
         Invocation.method(
           #getStatePension,

--- a/test/screens/settings_screen_test.mocks.dart
+++ b/test/screens/settings_screen_test.mocks.dart
@@ -598,6 +598,24 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
       ) as _i6.Future<int>);
 
   @override
+  _i6.Future<bool> doesStatementDateExist(
+    int? id,
+    int? pensionId,
+    DateTime? statementDate,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #doesStatementDateExist,
+          [
+            id,
+            pensionId,
+            statementDate,
+          ],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
+
+  @override
   _i6.Future<_i4.StatePension?> getStatePension() => (super.noSuchMethod(
         Invocation.method(
           #getStatePension,

--- a/test/widgets/date_field_test.dart
+++ b/test/widgets/date_field_test.dart
@@ -9,14 +9,17 @@ final _formKey = GlobalKey<FormState>();
 Widget createDateField(
     DateTime? initialDate,
     String labelText,
+    String? errorText,
     Function(DateTime?) onDateSelected,
     String? Function(DateTime?)? onValidate) {
   DateField field = DateField(
-      key: key,
-      initialDate: initialDate,
-      onDateSelected: onDateSelected,
-      onValidate: onValidate,
-      labelText: labelText);
+    key: key,
+    initialDate: initialDate,
+    onDateSelected: onDateSelected,
+    onValidate: onValidate,
+    labelText: labelText,
+    errorText: errorText,
+  );
 
   return StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
     return MaterialApp(
@@ -32,7 +35,7 @@ void main() {
   group('Test building dropdown', () {
     testWidgets('show the widget with no initial value', (tester) async {
       String label = 'test date field';
-      await tester.pumpWidget(createDateField(null, label, (_) {}, (_) {
+      await tester.pumpWidget(createDateField(null, label, null, (_) {}, (_) {
         return null;
       }));
       await tester.pumpAndSettle();
@@ -42,13 +45,16 @@ void main() {
 
     testWidgets('show the widget with initial value', (tester) async {
       String label = 'test date field';
+      String error = 'error msg';
       DateTime initialDate = DateTime(2024, 2, 15);
-      await tester.pumpWidget(createDateField(initialDate, label, (_) {}, (_) {
+      await tester
+          .pumpWidget(createDateField(initialDate, label, error, (_) {}, (_) {
         return null;
       }));
       await tester.pumpAndSettle();
 
       expect(find.bySemanticsLabel(label), findsOneWidget);
+      expect(find.bySemanticsLabel(error), findsOneWidget);
       expect(find.text(DateHelper.formatDate(initialDate)), findsOneWidget);
     });
 
@@ -65,7 +71,7 @@ void main() {
       }
 
       await tester.pumpWidget(
-          createDateField(initialDate, label, onSelectionChanged, (_) {
+          createDateField(initialDate, label, null, onSelectionChanged, (_) {
         return null;
       }));
 
@@ -109,7 +115,7 @@ void main() {
       }
 
       await tester.pumpWidget(
-          createDateField(null, label, onSelectionChanged, onValidate));
+          createDateField(null, label, null, onSelectionChanged, onValidate));
       await tester.pumpAndSettle();
 
       bool isValid = _formKey.currentState!.validate();
@@ -140,8 +146,8 @@ void main() {
         return value == null ? validationMessage : null;
       }
 
-      await tester.pumpWidget(
-          createDateField(initialDate, label, onSelectionChanged, onValidate));
+      await tester.pumpWidget(createDateField(
+          initialDate, label, null, onSelectionChanged, onValidate));
       await tester.pumpAndSettle();
 
       // Find the TextFormField by key

--- a/test/widgets/pension_dropdown_test.mocks.dart
+++ b/test/widgets/pension_dropdown_test.mocks.dart
@@ -552,6 +552,24 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<int>);
 
   @override
+  _i5.Future<bool> doesStatementDateExist(
+    int? id,
+    int? pensionId,
+    DateTime? statementDate,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #doesStatementDateExist,
+          [
+            id,
+            pensionId,
+            statementDate,
+          ],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
   _i5.Future<_i3.StatePension?> getStatePension() => (super.noSuchMethod(
         Invocation.method(
           #getStatePension,


### PR DESCRIPTION
Add validation to prevent duplicate statement dates for a pension record.

Required changes to 
 - DateField widget to allow the errorText to be set
 - DatabaseService to ensure statement date is always saved with just the date component, with time part set to 0:0:0
 - DateHelper to add a helper method to strip the time from a DateTime object

Resolves #14