### PR TITLE
feat: reset minSdkVersion to use flutter default

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -45,8 +45,7 @@ android {
         applicationId "com.example.pension_compare"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        //minSdkVersion flutter.minSdkVersion
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion        
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Restore the build.gradle to use flutter.minSdkVersion, altered in #8
Requires Flutter 3.22 
Resolves #10 