### PR TITLE
Bugfix/fix sort orders

### DIFF
--- a/lib/app/statement/views/widgets/statement_data_table.dart
+++ b/lib/app/statement/views/widgets/statement_data_table.dart
@@ -16,12 +16,18 @@ class StatementDataTable extends StatefulWidget {
 }
 
 class _StatementDataTableState extends State<StatementDataTable> {
+  List<StatementModel> _dataList = [];
+
   @override
   Widget build(BuildContext context) {
     if (widget.statementDataList.isEmpty) {
       return const Center(
           child: Text('No statements found.  Click + to add one'));
     }
+
+    _dataList = List.from(widget.statementDataList);
+    _dataList.sort((a, b) => b.statementDate.compareTo(a.statementDate));
+
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: DataTable(
@@ -65,9 +71,8 @@ class _StatementDataTableState extends State<StatementDataTable> {
             ),
           ),
         ],
-        rows: List<DataRow>.generate(widget.statementDataList.length,
-            (int index) {
-          StatementModel statementData = widget.statementDataList[index];
+        rows: List<DataRow>.generate(_dataList.length, (int index) {
+          StatementModel statementData = _dataList[index];
           return DataRow(
             onSelectChanged: (bool? selected) => widget.onTap(statementData),
             cells: <DataCell>[

--- a/lib/app/statement/views/widgets/statement_summary_chart.dart
+++ b/lib/app/statement/views/widgets/statement_summary_chart.dart
@@ -16,6 +16,7 @@ class StatementSummaryChart extends StatefulWidget {
 }
 
 class _StatementSummaryChartState extends State<StatementSummaryChart> {
+  List<StatementModel> _chartData = [];
   PensionSummaryChartStyles _selectedStyle =
       PensionSummaryChartStyles.planValue;
   static const double barWidth = 30;
@@ -28,9 +29,12 @@ class _StatementSummaryChartState extends State<StatementSummaryChart> {
       return const Center(child: Text('No data'));
     }
 
+    _chartData = List.from(widget.statementData!);
+    _chartData.sort((a, b) => a.statementDate.compareTo(b.statementDate));
+
     ChartColorConstants chartColorConstants = getIt<ChartColorConstants>();
-    _barColor = chartColorConstants
-        .getColorForPension(widget.statementData!.first.pension);
+    _barColor =
+        chartColorConstants.getColorForPension(_chartData.first.pension);
 
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
@@ -94,7 +98,7 @@ class _StatementSummaryChartState extends State<StatementSummaryChart> {
             int rodIndex,
           ) {
             return BarTooltipItem(
-              '${DateHelper.formatDate(widget.statementData![groupIndex].statementDate)}\n'
+              '${DateHelper.formatDate(_chartData[groupIndex].statementDate)}\n'
               '${CurrencyHelper.formatCurrency(rod.toY, _currencySymbol)}',
               const TextStyle(
                 color: Colors.white,
@@ -106,8 +110,7 @@ class _StatementSummaryChartState extends State<StatementSummaryChart> {
       );
 
   Widget getBottomTitles(double value, TitleMeta meta) {
-    String text =
-        widget.statementData![value.toInt()].statementDate.year.toString();
+    String text = _chartData[value.toInt()].statementDate.year.toString();
 
     return SideTitleWidget(
       axisSide: meta.axisSide,
@@ -157,7 +160,7 @@ class _StatementSummaryChartState extends State<StatementSummaryChart> {
         show: false,
       );
 
-  List<BarChartGroupData> get planValueBarGroups => widget.statementData!
+  List<BarChartGroupData> get planValueBarGroups => _chartData
       .asMap()
       .entries
       .map((entry) => BarChartGroupData(
@@ -166,17 +169,16 @@ class _StatementSummaryChartState extends State<StatementSummaryChart> {
           ))
       .toList();
 
-  List<BarChartGroupData> get projectedAnnualAmountBarGroups =>
-      widget.statementData!
-          .asMap()
-          .entries
-          .map((entry) => BarChartGroupData(
-                x: entry.key,
-                barRods: [buildBarRodData(entry.value.projectedAnnualAmount)],
-              ))
-          .toList();
+  List<BarChartGroupData> get projectedAnnualAmountBarGroups => _chartData
+      .asMap()
+      .entries
+      .map((entry) => BarChartGroupData(
+            x: entry.key,
+            barRods: [buildBarRodData(entry.value.projectedAnnualAmount)],
+          ))
+      .toList();
 
-  List<BarChartGroupData> get yearlyChargesBarGroups => widget.statementData!
+  List<BarChartGroupData> get yearlyChargesBarGroups => _chartData
       .asMap()
       .entries
       .map((entry) => BarChartGroupData(
@@ -185,7 +187,7 @@ class _StatementSummaryChartState extends State<StatementSummaryChart> {
           ))
       .toList();
 
-  List<BarChartGroupData> get transferValueBarGroups => widget.statementData!
+  List<BarChartGroupData> get transferValueBarGroups => _chartData
       .asMap()
       .entries
       .map((entry) => BarChartGroupData(
@@ -194,7 +196,7 @@ class _StatementSummaryChartState extends State<StatementSummaryChart> {
           ))
       .toList();
 
-  List<BarChartGroupData> get amountPaidInBarGroups => widget.statementData!
+  List<BarChartGroupData> get amountPaidInBarGroups => _chartData
       .asMap()
       .entries
       .map((entry) => BarChartGroupData(

--- a/lib/data/database/database_service.dart
+++ b/lib/data/database/database_service.dart
@@ -68,7 +68,8 @@ class DatabaseService extends _$DatabaseService {
 
   // List all the pensions in the database
   Stream<List<Pension>> getAllPensions() {
-    return select(pensions).watch();
+    return (select(pensions)..orderBy([(p) => OrderingTerm.asc(p.name)]))
+        .watch();
   }
 
   // Get a single pension by its id
@@ -122,7 +123,9 @@ class DatabaseService extends _$DatabaseService {
 
   // List all the statements in the database for a given pension
   Stream<List<Statement>> getAllStatementsForPension(int pensionId) {
-    return (select(statements)..where((s) => s.pension.equals(pensionId)))
+    return (select(statements)
+          ..where((s) => s.pension.equals(pensionId))
+          ..orderBy([(s) => OrderingTerm.desc(s.statementDate)]))
         .watch();
   }
 

--- a/lib/data/database/database_service.dart
+++ b/lib/data/database/database_service.dart
@@ -125,7 +125,7 @@ class DatabaseService extends _$DatabaseService {
   Stream<List<Statement>> getAllStatementsForPension(int pensionId) {
     return (select(statements)
           ..where((s) => s.pension.equals(pensionId))
-          ..orderBy([(s) => OrderingTerm.desc(s.statementDate)]))
+          ..orderBy([(s) => OrderingTerm.asc(s.statementDate)]))
         .watch();
   }
 


### PR DESCRIPTION
Fixed sort order for statements and pensions.  By default the pensions are sorted alphabetically. By default statements are sorted ascending by date.  Charts sort statements to show earliest first.  Datatable sort statements to show newest first.
 
Resolves #76