### PR TITLE
feat: add status field to pension object

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,1 +1,2 @@
 extensions:
+  - drift: true

--- a/lib/app/pension/controllers/pension_controller.dart
+++ b/lib/app/pension/controllers/pension_controller.dart
@@ -33,7 +33,7 @@ class PensionController extends _$PensionController {
     return _databaseService.deletePension(id);
   }
 
-  Future<bool> updatePension(int id, String name, DateTime maturityDate) {
+  Future<int> updatePension(int id, String name, DateTime maturityDate) {
     return _databaseService.updatePension(id, name, maturityDate, null);
   }
 

--- a/lib/app/pension/controllers/pension_controller.g.dart
+++ b/lib/app/pension/controllers/pension_controller.g.dart
@@ -6,7 +6,7 @@ part of 'pension_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$pensionControllerHash() => r'5ed066d29a519cd2277fe43bc10de8aa62afa685';
+String _$pensionControllerHash() => r'6e444f750434cc8d4dfe1a1b4b66e4c50583f119';
 
 /// See also [PensionController].
 @ProviderFor(PensionController)

--- a/lib/app/pension/models/pension_model.dart
+++ b/lib/app/pension/models/pension_model.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter/foundation.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 
 part 'pension_model.freezed.dart';
 part 'pension_model.g.dart';
@@ -10,6 +11,8 @@ class PensionModel with _$PensionModel {
     int? pensionId,
     required String name,
     DateTime? maturityDate,
+    required PensionStatus status,
+    required DateTime statusDate,
   }) = _PensionModel;
 
   factory PensionModel.fromJson(Map<String, Object?> json) =>

--- a/lib/app/pension/models/pension_model.freezed.dart
+++ b/lib/app/pension/models/pension_model.freezed.dart
@@ -23,6 +23,8 @@ mixin _$PensionModel {
   int? get pensionId => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
   DateTime? get maturityDate => throw _privateConstructorUsedError;
+  PensionStatus get status => throw _privateConstructorUsedError;
+  DateTime get statusDate => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -36,7 +38,12 @@ abstract class $PensionModelCopyWith<$Res> {
           PensionModel value, $Res Function(PensionModel) then) =
       _$PensionModelCopyWithImpl<$Res, PensionModel>;
   @useResult
-  $Res call({int? pensionId, String name, DateTime? maturityDate});
+  $Res call(
+      {int? pensionId,
+      String name,
+      DateTime? maturityDate,
+      PensionStatus status,
+      DateTime statusDate});
 }
 
 /// @nodoc
@@ -55,6 +62,8 @@ class _$PensionModelCopyWithImpl<$Res, $Val extends PensionModel>
     Object? pensionId = freezed,
     Object? name = null,
     Object? maturityDate = freezed,
+    Object? status = null,
+    Object? statusDate = null,
   }) {
     return _then(_value.copyWith(
       pensionId: freezed == pensionId
@@ -69,6 +78,14 @@ class _$PensionModelCopyWithImpl<$Res, $Val extends PensionModel>
           ? _value.maturityDate
           : maturityDate // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as PensionStatus,
+      statusDate: null == statusDate
+          ? _value.statusDate
+          : statusDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
     ) as $Val);
   }
 }
@@ -81,7 +98,12 @@ abstract class _$$PensionModelImplCopyWith<$Res>
       __$$PensionModelImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int? pensionId, String name, DateTime? maturityDate});
+  $Res call(
+      {int? pensionId,
+      String name,
+      DateTime? maturityDate,
+      PensionStatus status,
+      DateTime statusDate});
 }
 
 /// @nodoc
@@ -98,6 +120,8 @@ class __$$PensionModelImplCopyWithImpl<$Res>
     Object? pensionId = freezed,
     Object? name = null,
     Object? maturityDate = freezed,
+    Object? status = null,
+    Object? statusDate = null,
   }) {
     return _then(_$PensionModelImpl(
       pensionId: freezed == pensionId
@@ -112,6 +136,14 @@ class __$$PensionModelImplCopyWithImpl<$Res>
           ? _value.maturityDate
           : maturityDate // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as PensionStatus,
+      statusDate: null == statusDate
+          ? _value.statusDate
+          : statusDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
     ));
   }
 }
@@ -120,7 +152,11 @@ class __$$PensionModelImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$PensionModelImpl with DiagnosticableTreeMixin implements _PensionModel {
   const _$PensionModelImpl(
-      {this.pensionId, required this.name, this.maturityDate});
+      {this.pensionId,
+      required this.name,
+      this.maturityDate,
+      required this.status,
+      required this.statusDate});
 
   factory _$PensionModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$PensionModelImplFromJson(json);
@@ -131,10 +167,14 @@ class _$PensionModelImpl with DiagnosticableTreeMixin implements _PensionModel {
   final String name;
   @override
   final DateTime? maturityDate;
+  @override
+  final PensionStatus status;
+  @override
+  final DateTime statusDate;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'PensionModel(pensionId: $pensionId, name: $name, maturityDate: $maturityDate)';
+    return 'PensionModel(pensionId: $pensionId, name: $name, maturityDate: $maturityDate, status: $status, statusDate: $statusDate)';
   }
 
   @override
@@ -144,7 +184,9 @@ class _$PensionModelImpl with DiagnosticableTreeMixin implements _PensionModel {
       ..add(DiagnosticsProperty('type', 'PensionModel'))
       ..add(DiagnosticsProperty('pensionId', pensionId))
       ..add(DiagnosticsProperty('name', name))
-      ..add(DiagnosticsProperty('maturityDate', maturityDate));
+      ..add(DiagnosticsProperty('maturityDate', maturityDate))
+      ..add(DiagnosticsProperty('status', status))
+      ..add(DiagnosticsProperty('statusDate', statusDate));
   }
 
   @override
@@ -156,12 +198,16 @@ class _$PensionModelImpl with DiagnosticableTreeMixin implements _PensionModel {
                 other.pensionId == pensionId) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.maturityDate, maturityDate) ||
-                other.maturityDate == maturityDate));
+                other.maturityDate == maturityDate) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.statusDate, statusDate) ||
+                other.statusDate == statusDate));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, pensionId, name, maturityDate);
+  int get hashCode => Object.hash(
+      runtimeType, pensionId, name, maturityDate, status, statusDate);
 
   @JsonKey(ignore: true)
   @override
@@ -181,7 +227,9 @@ abstract class _PensionModel implements PensionModel {
   const factory _PensionModel(
       {final int? pensionId,
       required final String name,
-      final DateTime? maturityDate}) = _$PensionModelImpl;
+      final DateTime? maturityDate,
+      required final PensionStatus status,
+      required final DateTime statusDate}) = _$PensionModelImpl;
 
   factory _PensionModel.fromJson(Map<String, dynamic> json) =
       _$PensionModelImpl.fromJson;
@@ -192,6 +240,10 @@ abstract class _PensionModel implements PensionModel {
   String get name;
   @override
   DateTime? get maturityDate;
+  @override
+  PensionStatus get status;
+  @override
+  DateTime get statusDate;
   @override
   @JsonKey(ignore: true)
   _$$PensionModelImplCopyWith<_$PensionModelImpl> get copyWith =>

--- a/lib/app/pension/models/pension_model.g.dart
+++ b/lib/app/pension/models/pension_model.g.dart
@@ -13,6 +13,8 @@ _$PensionModelImpl _$$PensionModelImplFromJson(Map<String, dynamic> json) =>
       maturityDate: json['maturityDate'] == null
           ? null
           : DateTime.parse(json['maturityDate'] as String),
+      status: $enumDecode(_$PensionStatusEnumMap, json['status']),
+      statusDate: DateTime.parse(json['statusDate'] as String),
     );
 
 Map<String, dynamic> _$$PensionModelImplToJson(_$PensionModelImpl instance) =>
@@ -20,4 +22,13 @@ Map<String, dynamic> _$$PensionModelImplToJson(_$PensionModelImpl instance) =>
       'pensionId': instance.pensionId,
       'name': instance.name,
       'maturityDate': instance.maturityDate?.toIso8601String(),
+      'status': _$PensionStatusEnumMap[instance.status]!,
+      'statusDate': instance.statusDate.toIso8601String(),
     };
+
+const _$PensionStatusEnumMap = {
+  PensionStatus.active: 'active',
+  PensionStatus.closed: 'closed',
+  PensionStatus.transferred: 'transferred',
+  PensionStatus.matured: 'matured',
+};

--- a/lib/app/pension/views/widgets/pension_summary_chart.dart
+++ b/lib/app/pension/views/widgets/pension_summary_chart.dart
@@ -238,7 +238,7 @@ class _PensionSummaryChartState extends State<PensionSummaryChart> {
                   entry.value.pension, entry.value.statement?.amountPaidIn)
             ],
           ))
-      .toList();      
+      .toList();
 
   BarChartRodData buildBarRodData(PensionModel pension, double? value) {
     ChartColorConstants chartColorConstants = getIt<ChartColorConstants>();

--- a/lib/constants/pension_status.dart
+++ b/lib/constants/pension_status.dart
@@ -1,0 +1,30 @@
+enum PensionStatus implements Comparable<PensionStatus> {
+  active(dataValue: 0),
+  closed(dataValue: 1),
+  transferred(dataValue: 2),
+  matured(dataValue: 3);
+
+  final int dataValue;
+
+  const PensionStatus({required this.dataValue});
+
+  static PensionStatus fromDataValue(int dataValue) {
+    switch (dataValue) {
+      case 0:
+        return PensionStatus.active;
+      case 1:
+        return PensionStatus.closed;
+      case 2:
+        return PensionStatus.transferred;
+      case 3:
+        return PensionStatus.matured;
+      default:
+        throw Exception('Unknown data value for PensionStatus: $dataValue');
+    }
+  }
+
+  @override
+  int compareTo(PensionStatus other) {
+    return dataValue.compareTo(other.dataValue);
+  }
+}

--- a/lib/data/database/database_service.dart
+++ b/lib/data/database/database_service.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart';
 import 'package:pension_compare/app/passcode/controller/passcode_service.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/tables/secure_setting.dart';
 import 'package:pension_compare/data/database/tables/yearly_pension_statement.dart';
 import 'package:pension_compare/service_locator.dart';
@@ -88,19 +89,24 @@ class DatabaseService extends _$DatabaseService {
   Future<Pension?> createPension(
       String name, DateTime maturityDate, String? notes) {
     return into(pensions).insertReturningOrNull(PensionsCompanion.insert(
-        name: name,
-        maturityDate: DateHelper.removeTime(maturityDate),
-        notes: Value(notes)));
+      name: name,
+      maturityDate: DateHelper.removeTime(maturityDate),
+      notes: Value(notes),
+      status: Value(PensionStatus.active.dataValue),
+      statusDate: Value(DateTime.now()),
+    ));
   }
 
-  // Update an existing pension record, return true if successful
-  Future<bool> updatePension(
+  // Update an existing pension record, return the number of records updated
+  Future<int> updatePension(
       int id, String name, DateTime maturityDate, String? notes) {
-    return update(pensions).replace(Pension(
-        pensionId: id,
-        name: name,
-        maturityDate: DateHelper.removeTime(maturityDate),
-        notes: notes));
+    return (update(pensions)..where((p) => p.pensionId.equals(id)))
+        .write(PensionsCompanion.insert(
+      pensionId: Value(id),
+      name: name,
+      maturityDate: DateHelper.removeTime(maturityDate),
+      notes: Value(notes),
+    ));
   }
 
   // Delete a pension record by its id and return the number of records deleted

--- a/lib/data/database/database_service.g.dart
+++ b/lib/data/database/database_service.g.dart
@@ -37,8 +37,24 @@ class $PensionsTable extends Pensions with TableInfo<$PensionsTable, Pension> {
   late final GeneratedColumn<String> notes = GeneratedColumn<String>(
       'notes', aliasedName, true,
       type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
   @override
-  List<GeneratedColumn> get $columns => [pensionId, name, maturityDate, notes];
+  late final GeneratedColumn<int> status = GeneratedColumn<int>(
+      'status', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: Constant(PensionStatus.active.dataValue));
+  static const VerificationMeta _statusDateMeta =
+      const VerificationMeta('statusDate');
+  @override
+  late final GeneratedColumn<DateTime> statusDate = GeneratedColumn<DateTime>(
+      'status_date', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [pensionId, name, maturityDate, notes, status, statusDate];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -71,6 +87,16 @@ class $PensionsTable extends Pensions with TableInfo<$PensionsTable, Pension> {
       context.handle(
           _notesMeta, notes.isAcceptableOrUnknown(data['notes']!, _notesMeta));
     }
+    if (data.containsKey('status')) {
+      context.handle(_statusMeta,
+          status.isAcceptableOrUnknown(data['status']!, _statusMeta));
+    }
+    if (data.containsKey('status_date')) {
+      context.handle(
+          _statusDateMeta,
+          statusDate.isAcceptableOrUnknown(
+              data['status_date']!, _statusDateMeta));
+    }
     return context;
   }
 
@@ -88,6 +114,10 @@ class $PensionsTable extends Pensions with TableInfo<$PensionsTable, Pension> {
           DriftSqlType.dateTime, data['${effectivePrefix}maturity_date'])!,
       notes: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}notes']),
+      status: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}status'])!,
+      statusDate: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}status_date'])!,
     );
   }
 
@@ -102,11 +132,15 @@ class Pension extends DataClass implements Insertable<Pension> {
   final String name;
   final DateTime maturityDate;
   final String? notes;
+  final int status;
+  final DateTime statusDate;
   const Pension(
       {required this.pensionId,
       required this.name,
       required this.maturityDate,
-      this.notes});
+      this.notes,
+      required this.status,
+      required this.statusDate});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -116,6 +150,8 @@ class Pension extends DataClass implements Insertable<Pension> {
     if (!nullToAbsent || notes != null) {
       map['notes'] = Variable<String>(notes);
     }
+    map['status'] = Variable<int>(status);
+    map['status_date'] = Variable<DateTime>(statusDate);
     return map;
   }
 
@@ -126,6 +162,8 @@ class Pension extends DataClass implements Insertable<Pension> {
       maturityDate: Value(maturityDate),
       notes:
           notes == null && nullToAbsent ? const Value.absent() : Value(notes),
+      status: Value(status),
+      statusDate: Value(statusDate),
     );
   }
 
@@ -137,6 +175,8 @@ class Pension extends DataClass implements Insertable<Pension> {
       name: serializer.fromJson<String>(json['name']),
       maturityDate: serializer.fromJson<DateTime>(json['maturityDate']),
       notes: serializer.fromJson<String?>(json['notes']),
+      status: serializer.fromJson<int>(json['status']),
+      statusDate: serializer.fromJson<DateTime>(json['statusDate']),
     );
   }
   @override
@@ -147,6 +187,8 @@ class Pension extends DataClass implements Insertable<Pension> {
       'name': serializer.toJson<String>(name),
       'maturityDate': serializer.toJson<DateTime>(maturityDate),
       'notes': serializer.toJson<String?>(notes),
+      'status': serializer.toJson<int>(status),
+      'statusDate': serializer.toJson<DateTime>(statusDate),
     };
   }
 
@@ -154,12 +196,16 @@ class Pension extends DataClass implements Insertable<Pension> {
           {int? pensionId,
           String? name,
           DateTime? maturityDate,
-          Value<String?> notes = const Value.absent()}) =>
+          Value<String?> notes = const Value.absent(),
+          int? status,
+          DateTime? statusDate}) =>
       Pension(
         pensionId: pensionId ?? this.pensionId,
         name: name ?? this.name,
         maturityDate: maturityDate ?? this.maturityDate,
         notes: notes.present ? notes.value : this.notes,
+        status: status ?? this.status,
+        statusDate: statusDate ?? this.statusDate,
       );
   @override
   String toString() {
@@ -167,13 +213,16 @@ class Pension extends DataClass implements Insertable<Pension> {
           ..write('pensionId: $pensionId, ')
           ..write('name: $name, ')
           ..write('maturityDate: $maturityDate, ')
-          ..write('notes: $notes')
+          ..write('notes: $notes, ')
+          ..write('status: $status, ')
+          ..write('statusDate: $statusDate')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(pensionId, name, maturityDate, notes);
+  int get hashCode =>
+      Object.hash(pensionId, name, maturityDate, notes, status, statusDate);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -181,7 +230,9 @@ class Pension extends DataClass implements Insertable<Pension> {
           other.pensionId == this.pensionId &&
           other.name == this.name &&
           other.maturityDate == this.maturityDate &&
-          other.notes == this.notes);
+          other.notes == this.notes &&
+          other.status == this.status &&
+          other.statusDate == this.statusDate);
 }
 
 class PensionsCompanion extends UpdateCompanion<Pension> {
@@ -189,17 +240,23 @@ class PensionsCompanion extends UpdateCompanion<Pension> {
   final Value<String> name;
   final Value<DateTime> maturityDate;
   final Value<String?> notes;
+  final Value<int> status;
+  final Value<DateTime> statusDate;
   const PensionsCompanion({
     this.pensionId = const Value.absent(),
     this.name = const Value.absent(),
     this.maturityDate = const Value.absent(),
     this.notes = const Value.absent(),
+    this.status = const Value.absent(),
+    this.statusDate = const Value.absent(),
   });
   PensionsCompanion.insert({
     this.pensionId = const Value.absent(),
     required String name,
     required DateTime maturityDate,
     this.notes = const Value.absent(),
+    this.status = const Value.absent(),
+    this.statusDate = const Value.absent(),
   })  : name = Value(name),
         maturityDate = Value(maturityDate);
   static Insertable<Pension> custom({
@@ -207,12 +264,16 @@ class PensionsCompanion extends UpdateCompanion<Pension> {
     Expression<String>? name,
     Expression<DateTime>? maturityDate,
     Expression<String>? notes,
+    Expression<int>? status,
+    Expression<DateTime>? statusDate,
   }) {
     return RawValuesInsertable({
       if (pensionId != null) 'pension_id': pensionId,
       if (name != null) 'name': name,
       if (maturityDate != null) 'maturity_date': maturityDate,
       if (notes != null) 'notes': notes,
+      if (status != null) 'status': status,
+      if (statusDate != null) 'status_date': statusDate,
     });
   }
 
@@ -220,12 +281,16 @@ class PensionsCompanion extends UpdateCompanion<Pension> {
       {Value<int>? pensionId,
       Value<String>? name,
       Value<DateTime>? maturityDate,
-      Value<String?>? notes}) {
+      Value<String?>? notes,
+      Value<int>? status,
+      Value<DateTime>? statusDate}) {
     return PensionsCompanion(
       pensionId: pensionId ?? this.pensionId,
       name: name ?? this.name,
       maturityDate: maturityDate ?? this.maturityDate,
       notes: notes ?? this.notes,
+      status: status ?? this.status,
+      statusDate: statusDate ?? this.statusDate,
     );
   }
 
@@ -244,6 +309,12 @@ class PensionsCompanion extends UpdateCompanion<Pension> {
     if (notes.present) {
       map['notes'] = Variable<String>(notes.value);
     }
+    if (status.present) {
+      map['status'] = Variable<int>(status.value);
+    }
+    if (statusDate.present) {
+      map['status_date'] = Variable<DateTime>(statusDate.value);
+    }
     return map;
   }
 
@@ -253,7 +324,9 @@ class PensionsCompanion extends UpdateCompanion<Pension> {
           ..write('pensionId: $pensionId, ')
           ..write('name: $name, ')
           ..write('maturityDate: $maturityDate, ')
-          ..write('notes: $notes')
+          ..write('notes: $notes, ')
+          ..write('status: $status, ')
+          ..write('statusDate: $statusDate')
           ..write(')'))
         .toString();
   }

--- a/lib/data/database/tables/pension.dart
+++ b/lib/data/database/tables/pension.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 
 // Table definition for pensions table
 // Need to run 'dart run build_runner build' after making changes to this file
@@ -8,5 +9,7 @@ class Pensions extends Table {
   TextColumn get name => text().unique().withLength(max: 100)();
   DateTimeColumn get maturityDate => dateTime()();
   TextColumn get notes => text().nullable()();
-  
+  IntColumn get status =>
+      integer().withDefault(Constant(PensionStatus.active.dataValue))();
+  DateTimeColumn get statusDate => dateTime().withDefault(currentDateAndTime)();
 }

--- a/lib/data/import_export/mapper/pension_mapper.dart
+++ b/lib/data/import_export/mapper/pension_mapper.dart
@@ -1,3 +1,4 @@
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:pension_compare/data/import_export/models/transfer_pension_model.dart';
 import 'package:pension_compare/data/import_export/models/transfer_statement_model.dart';
@@ -10,6 +11,8 @@ class PensionMapper {
       name: pension.name,
       maturityDate: pension.maturityDate,
       notes: pension.notes,
+      status: PensionStatus.fromDataValue(pension.status),
+      statusDate: pension.statusDate,
       statements: statements
           .map((statement) => TransferStatementModel(
                 statementId: statement.statementId,
@@ -27,10 +30,13 @@ class PensionMapper {
 
   static Pension pensionFromTransfer(TransferPensionModel pension) {
     return Pension(
-        pensionId: pension.pensionId,
-        name: pension.name,
-        maturityDate: pension.maturityDate,
-        notes: pension.notes);
+      pensionId: pension.pensionId,
+      name: pension.name,
+      maturityDate: pension.maturityDate,
+      notes: pension.notes,
+      status: pension.status.dataValue,
+      statusDate: pension.statusDate,
+    );
   }
 
   static List<Statement> statementFromTransfer(TransferPensionModel pension) {

--- a/lib/data/import_export/models/transfer_pension_model.dart
+++ b/lib/data/import_export/models/transfer_pension_model.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter/foundation.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/import_export/models/transfer_statement_model.dart';
 
 part 'transfer_pension_model.freezed.dart';
@@ -11,6 +12,8 @@ class TransferPensionModel with _$TransferPensionModel {
     required int pensionId,
     required String name,
     required DateTime maturityDate,
+    required PensionStatus status,
+    required DateTime statusDate,
     required List<TransferStatementModel> statements,
     String? notes,
   }) = _TransferPensionModel;

--- a/lib/data/import_export/models/transfer_pension_model.freezed.dart
+++ b/lib/data/import_export/models/transfer_pension_model.freezed.dart
@@ -23,6 +23,8 @@ mixin _$TransferPensionModel {
   int get pensionId => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
   DateTime get maturityDate => throw _privateConstructorUsedError;
+  PensionStatus get status => throw _privateConstructorUsedError;
+  DateTime get statusDate => throw _privateConstructorUsedError;
   List<TransferStatementModel> get statements =>
       throw _privateConstructorUsedError;
   String? get notes => throw _privateConstructorUsedError;
@@ -43,6 +45,8 @@ abstract class $TransferPensionModelCopyWith<$Res> {
       {int pensionId,
       String name,
       DateTime maturityDate,
+      PensionStatus status,
+      DateTime statusDate,
       List<TransferStatementModel> statements,
       String? notes});
 }
@@ -64,6 +68,8 @@ class _$TransferPensionModelCopyWithImpl<$Res,
     Object? pensionId = null,
     Object? name = null,
     Object? maturityDate = null,
+    Object? status = null,
+    Object? statusDate = null,
     Object? statements = null,
     Object? notes = freezed,
   }) {
@@ -79,6 +85,14 @@ class _$TransferPensionModelCopyWithImpl<$Res,
       maturityDate: null == maturityDate
           ? _value.maturityDate
           : maturityDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as PensionStatus,
+      statusDate: null == statusDate
+          ? _value.statusDate
+          : statusDate // ignore: cast_nullable_to_non_nullable
               as DateTime,
       statements: null == statements
           ? _value.statements
@@ -104,6 +118,8 @@ abstract class _$$TransferPensionModelImplCopyWith<$Res>
       {int pensionId,
       String name,
       DateTime maturityDate,
+      PensionStatus status,
+      DateTime statusDate,
       List<TransferStatementModel> statements,
       String? notes});
 }
@@ -122,6 +138,8 @@ class __$$TransferPensionModelImplCopyWithImpl<$Res>
     Object? pensionId = null,
     Object? name = null,
     Object? maturityDate = null,
+    Object? status = null,
+    Object? statusDate = null,
     Object? statements = null,
     Object? notes = freezed,
   }) {
@@ -137,6 +155,14 @@ class __$$TransferPensionModelImplCopyWithImpl<$Res>
       maturityDate: null == maturityDate
           ? _value.maturityDate
           : maturityDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as PensionStatus,
+      statusDate: null == statusDate
+          ? _value.statusDate
+          : statusDate // ignore: cast_nullable_to_non_nullable
               as DateTime,
       statements: null == statements
           ? _value._statements
@@ -159,6 +185,8 @@ class _$TransferPensionModelImpl
       {required this.pensionId,
       required this.name,
       required this.maturityDate,
+      required this.status,
+      required this.statusDate,
       required final List<TransferStatementModel> statements,
       this.notes})
       : _statements = statements;
@@ -172,6 +200,10 @@ class _$TransferPensionModelImpl
   final String name;
   @override
   final DateTime maturityDate;
+  @override
+  final PensionStatus status;
+  @override
+  final DateTime statusDate;
   final List<TransferStatementModel> _statements;
   @override
   List<TransferStatementModel> get statements {
@@ -185,7 +217,7 @@ class _$TransferPensionModelImpl
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'TransferPensionModel(pensionId: $pensionId, name: $name, maturityDate: $maturityDate, statements: $statements, notes: $notes)';
+    return 'TransferPensionModel(pensionId: $pensionId, name: $name, maturityDate: $maturityDate, status: $status, statusDate: $statusDate, statements: $statements, notes: $notes)';
   }
 
   @override
@@ -196,6 +228,8 @@ class _$TransferPensionModelImpl
       ..add(DiagnosticsProperty('pensionId', pensionId))
       ..add(DiagnosticsProperty('name', name))
       ..add(DiagnosticsProperty('maturityDate', maturityDate))
+      ..add(DiagnosticsProperty('status', status))
+      ..add(DiagnosticsProperty('statusDate', statusDate))
       ..add(DiagnosticsProperty('statements', statements))
       ..add(DiagnosticsProperty('notes', notes));
   }
@@ -210,6 +244,9 @@ class _$TransferPensionModelImpl
             (identical(other.name, name) || other.name == name) &&
             (identical(other.maturityDate, maturityDate) ||
                 other.maturityDate == maturityDate) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.statusDate, statusDate) ||
+                other.statusDate == statusDate) &&
             const DeepCollectionEquality()
                 .equals(other._statements, _statements) &&
             (identical(other.notes, notes) || other.notes == notes));
@@ -217,8 +254,15 @@ class _$TransferPensionModelImpl
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, pensionId, name, maturityDate,
-      const DeepCollectionEquality().hash(_statements), notes);
+  int get hashCode => Object.hash(
+      runtimeType,
+      pensionId,
+      name,
+      maturityDate,
+      status,
+      statusDate,
+      const DeepCollectionEquality().hash(_statements),
+      notes);
 
   @JsonKey(ignore: true)
   @override
@@ -241,6 +285,8 @@ abstract class _TransferPensionModel implements TransferPensionModel {
       {required final int pensionId,
       required final String name,
       required final DateTime maturityDate,
+      required final PensionStatus status,
+      required final DateTime statusDate,
       required final List<TransferStatementModel> statements,
       final String? notes}) = _$TransferPensionModelImpl;
 
@@ -253,6 +299,10 @@ abstract class _TransferPensionModel implements TransferPensionModel {
   String get name;
   @override
   DateTime get maturityDate;
+  @override
+  PensionStatus get status;
+  @override
+  DateTime get statusDate;
   @override
   List<TransferStatementModel> get statements;
   @override

--- a/lib/data/import_export/models/transfer_pension_model.g.dart
+++ b/lib/data/import_export/models/transfer_pension_model.g.dart
@@ -12,6 +12,8 @@ _$TransferPensionModelImpl _$$TransferPensionModelImplFromJson(
       pensionId: (json['pensionId'] as num).toInt(),
       name: json['name'] as String,
       maturityDate: DateTime.parse(json['maturityDate'] as String),
+      status: $enumDecode(_$PensionStatusEnumMap, json['status']),
+      statusDate: DateTime.parse(json['statusDate'] as String),
       statements: (json['statements'] as List<dynamic>)
           .map(
               (e) => TransferStatementModel.fromJson(e as Map<String, dynamic>))
@@ -25,6 +27,15 @@ Map<String, dynamic> _$$TransferPensionModelImplToJson(
       'pensionId': instance.pensionId,
       'name': instance.name,
       'maturityDate': instance.maturityDate.toIso8601String(),
+      'status': _$PensionStatusEnumMap[instance.status]!,
+      'statusDate': instance.statusDate.toIso8601String(),
       'statements': instance.statements,
       'notes': instance.notes,
     };
+
+const _$PensionStatusEnumMap = {
+  PensionStatus.active: 'active',
+  PensionStatus.closed: 'closed',
+  PensionStatus.transferred: 'transferred',
+  PensionStatus.matured: 'matured',
+};

--- a/lib/data/mapper/pension_mapper.dart
+++ b/lib/data/mapper/pension_mapper.dart
@@ -1,3 +1,4 @@
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:pension_compare/app/pension/models/pension_model.dart';
 
@@ -7,6 +8,8 @@ class PensionMapper {
       pensionId: pension.pensionId,
       name: pension.name,
       maturityDate: pension.maturityDate,
+      status: PensionStatus.fromDataValue(pension.status),
+      statusDate: pension.statusDate,
     );
   }
 

--- a/test/app/home/controllers/pension_with_latest_statement_controller_test.dart
+++ b/test/app/home/controllers/pension_with_latest_statement_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:pension_compare/app/home/controllers/pension_with_latest_statement_controller.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -23,7 +24,9 @@ void main() {
                     Pension(
                         pensionId: pensionId,
                         name: pensionName,
-                        maturityDate: DateTime.now()),
+                        maturityDate: DateTime.now(),
+                        status: PensionStatus.active.dataValue,
+                        statusDate: DateTime.now()),
                     null)
               ]));
 

--- a/test/app/home/controllers/pension_with_latest_statement_controller_test.mocks.dart
+++ b/test/app/home/controllers/pension_with_latest_statement_controller_test.mocks.dart
@@ -494,7 +494,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -510,8 +510,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/home/controllers/yearly_pension_statement_controller_test.dart
+++ b/test/app/home/controllers/yearly_pension_statement_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:pension_compare/app/home/controllers/yearly_pension_statement_controller.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -25,7 +26,9 @@ void main() {
                       Pension(
                           pensionId: pensionId,
                           name: pensionName,
-                          maturityDate: DateTime.now()),
+                          maturityDate: DateTime.now(),
+                          status: PensionStatus.active.dataValue,
+                          statusDate: DateTime.now()),
                       null)
                 ])
               ]));
@@ -43,7 +46,8 @@ void main() {
       expect(pensionList[0].pensionWithStatement, isNotNull);
       expect(pensionList[0].pensionWithStatement.length, 1);
       expect(pensionList[0].pensionWithStatement[0].pension, isNotNull);
-      expect(pensionList[0].pensionWithStatement[0].pension.pensionId, pensionId);
+      expect(
+          pensionList[0].pensionWithStatement[0].pension.pensionId, pensionId);
       expect(pensionList[0].pensionWithStatement[0].pension.name, pensionName);
       expect(pensionList[0].pensionWithStatement[0].statement, isNull);
       verify(databaseService.getYearlyPensionSummary()).called(1);

--- a/test/app/home/controllers/yearly_pension_statement_controller_test.mocks.dart
+++ b/test/app/home/controllers/yearly_pension_statement_controller_test.mocks.dart
@@ -494,7 +494,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -510,8 +510,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/home/views/home_screen_test.dart
+++ b/test/app/home/views/home_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:pension_compare/app/settings/controllers/settings_service.dart';
 import 'package:pension_compare/app/settings/models/settings.dart';
 import 'package:pension_compare/constants/chart_color_constants.dart';
 import 'package:pension_compare/constants/defaults.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/tables/pensions_with_statement.dart';
 import 'package:pension_compare/app/home/views/home_screen.dart';
 import 'package:pension_compare/data/database/database_service.dart';
@@ -90,7 +91,9 @@ void main() {
                     Pension(
                         pensionId: pensionId,
                         name: pensionName,
-                        maturityDate: DateTime.now()),
+                        maturityDate: DateTime.now(),
+                        status: PensionStatus.active.dataValue,
+                        statusDate: DateTime.now()),
                     null)
               ]));
       when(databaseService.getSecureSettings())

--- a/test/app/home/views/home_screen_test.mocks.dart
+++ b/test/app/home/views/home_screen_test.mocks.dart
@@ -560,7 +560,7 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
       ) as _i6.Future<_i4.Pension?>);
 
   @override
-  _i6.Future<bool> updatePension(
+  _i6.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -576,8 +576,8 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i6.Future<int>.value(0),
+      ) as _i6.Future<int>);
 
   @override
   _i6.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/home/views/welcome_screen_test.mocks.dart
+++ b/test/app/home/views/welcome_screen_test.mocks.dart
@@ -561,7 +561,7 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
       ) as _i6.Future<_i4.Pension?>);
 
   @override
-  _i6.Future<bool> updatePension(
+  _i6.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -577,8 +577,8 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i6.Future<int>.value(0),
+      ) as _i6.Future<int>);
 
   @override
   _i6.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/otherIncome/controllers/other_income_controller_test.mocks.dart
+++ b/test/app/otherIncome/controllers/other_income_controller_test.mocks.dart
@@ -494,7 +494,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -510,8 +510,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/otherIncome/views/edit_state_pension_screen_test.mocks.dart
+++ b/test/app/otherIncome/views/edit_state_pension_screen_test.mocks.dart
@@ -494,7 +494,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -510,8 +510,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/passcode/views/change_passcode_screen_test.mocks.dart
+++ b/test/app/passcode/views/change_passcode_screen_test.mocks.dart
@@ -653,7 +653,7 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
       ) as _i6.Future<_i4.Pension?>);
 
   @override
-  _i6.Future<bool> updatePension(
+  _i6.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -669,8 +669,8 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i6.Future<int>.value(0),
+      ) as _i6.Future<int>);
 
   @override
   _i6.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/pension/controllers/pension_controller_test.dart
+++ b/test/app/pension/controllers/pension_controller_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:pension_compare/app/pension/controllers/pension_controller.dart';
 import 'package:pension_compare/app/pension/models/pension_model.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -17,12 +18,15 @@ void main() {
       int pensionId = 1;
       String pensionName = 'new pension';
       DateTime maturityDate = DateTime.now();
+      DateTime statusDate = DateTime.now();
       final databaseService = MockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
                 pensionId: pensionId,
                 name: pensionName,
-                maturityDate: maturityDate),
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: statusDate),
           ]));
 
       final container = createContainer(overrides: [
@@ -37,6 +41,8 @@ void main() {
       expect(pensionList[0].pensionId, pensionId);
       expect(pensionList[0].name, pensionName);
       expect(pensionList[0].maturityDate, maturityDate);
+      expect(pensionList[0].status, PensionStatus.active);
+      expect(pensionList[0].statusDate, statusDate);
       verify(databaseService.getAllPensions()).called(1);
 
       // Workaround to avoid the FakeTimer error
@@ -71,13 +77,16 @@ void main() {
       int pensionId = 1;
       String pensionName = 'new pension';
       DateTime maturityDate = DateTime.now();
+      DateTime statusDate = DateTime.now();
       final databaseService = MockDatabaseService();
       when(databaseService.createPension(pensionName, maturityDate, null))
           .thenAnswer(
         (_) async => Pension(
             pensionId: pensionId,
             name: pensionName,
-            maturityDate: maturityDate),
+            maturityDate: maturityDate,
+            status: PensionStatus.active.dataValue,
+            statusDate: statusDate),
       );
 
       final container = createContainer(overrides: [
@@ -91,6 +100,8 @@ void main() {
       expect(savedPension!.pensionId, pensionId);
       expect(savedPension.name, pensionName);
       expect(savedPension.maturityDate, maturityDate);
+      expect(savedPension.status, PensionStatus.active);
+      expect(savedPension.statusDate, statusDate);
       verify(databaseService.createPension(pensionName, maturityDate, null))
           .called(1);
 
@@ -107,16 +118,16 @@ void main() {
       final databaseService = MockDatabaseService();
       when(databaseService.updatePension(
               pensionId, pensionName, maturityDate, null))
-          .thenAnswer((_) async => true);
+          .thenAnswer((_) async => 1);
 
       final container = createContainer(overrides: [
         DatabaseService.provider.overrideWithValue(databaseService)
       ]);
       final provider = container.read(pensionControllerProvider.notifier);
-      bool result =
+      int result =
           await provider.updatePension(pensionId, pensionName, maturityDate);
 
-      expect(result, isTrue);
+      expect(result, 1);
       verify(databaseService.updatePension(
               pensionId, pensionName, maturityDate, null))
           .called(1);

--- a/test/app/pension/controllers/pension_controller_test.mocks.dart
+++ b/test/app/pension/controllers/pension_controller_test.mocks.dart
@@ -494,7 +494,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -510,8 +510,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/pension/controllers/single_pension_controller_test.dart
+++ b/test/app/pension/controllers/single_pension_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:pension_compare/app/pension/controllers/single_pension_controller.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -16,13 +17,16 @@ void main() {
       int pensionId = 1;
       String pensionName = 'new pension';
       DateTime maturityDate = DateTime.now();
+      DateTime statusDate = DateTime.now();
       final databaseService = MockDatabaseService();
       when(databaseService.watchPension(pensionId))
           .thenAnswer((_) => Stream.value(
                 Pension(
                     pensionId: pensionId,
                     name: pensionName,
-                    maturityDate: maturityDate),
+                    maturityDate: maturityDate,
+                    status: PensionStatus.active.dataValue,
+                    statusDate: statusDate),
               ));
 
       final container = createContainer(overrides: [
@@ -36,6 +40,8 @@ void main() {
       expect(pension!.pensionId, pensionId);
       expect(pension.name, pensionName);
       expect(pension.maturityDate, maturityDate);
+      expect(pension.status, PensionStatus.active);
+      expect(pension.statusDate, statusDate);
       verify(databaseService.watchPension(pensionId)).called(1);
 
       // Workaround to avoid the FakeTimer error

--- a/test/app/pension/controllers/single_pension_controller_test.mocks.dart
+++ b/test/app/pension/controllers/single_pension_controller_test.mocks.dart
@@ -494,7 +494,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -510,8 +510,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/pension/views/edit_pension_screen_test.dart
+++ b/test/app/pension/views/edit_pension_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:pension_compare/app/pension/views/edit_pension_screen.dart';
 import 'package:pension_compare/app/pension/views/pension_overview_screen.dart';
 import 'package:pension_compare/app/settings/controllers/settings_service.dart';
 import 'package:pension_compare/app/settings/models/settings.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:pension_compare/data/mapper/pension_mapper.dart';
 import 'package:pension_compare/helpers/date_helper.dart';
@@ -104,7 +105,11 @@ void main() {
 
     testWidgets('show the edit screen with a pension record', (tester) async {
       Pension p = Pension(
-          pensionId: 1, name: "Test Pension", maturityDate: DateTime.now());
+          pensionId: 1,
+          name: "Test Pension",
+          maturityDate: DateTime.now(),
+          status: PensionStatus.active.dataValue,
+          statusDate: DateTime.now());
       await tester.pumpWidget(createEditScreen(p, createMockDatabaseService()));
       await tester.pumpAndSettle();
 
@@ -152,8 +157,12 @@ void main() {
       when(databaseService.doesPensionNameExist(null, name))
           .thenAnswer((_) async => false);
       when(databaseService.createPension(name, maturityDate, null)).thenAnswer(
-          (_) async =>
-              Pension(pensionId: 1, name: name, maturityDate: maturityDate));
+          (_) async => Pension(
+              pensionId: 1,
+              name: name,
+              maturityDate: maturityDate,
+              status: PensionStatus.active.dataValue,
+              statusDate: DateTime.now()));
 
       await tester.pumpWidget(createEditScreen(null, databaseService, true));
 
@@ -187,14 +196,17 @@ void main() {
       when(databaseService.doesPensionNameExist(id, newName))
           .thenAnswer((_) async => false);
       when(databaseService.updatePension(id, newName, newMaturityDate, null))
-          .thenAnswer((_) async => true);
+          .thenAnswer((_) async => 1);
 
       await tester.pumpWidget(createEditScreen(
           Pension(
               pensionId: id,
               name: originalName,
-              maturityDate: originalMaturityDate),
-          databaseService, true));
+              maturityDate: originalMaturityDate,
+              status: PensionStatus.active.dataValue,
+              statusDate: DateTime.now()),
+          databaseService,
+          true));
 
       // Enter name into the TextFormField
       await tester.enterText(
@@ -210,7 +222,8 @@ void main() {
       // Tap the save button
       await tester.tap(find.widgetWithText(TextButton, "Save"));
 
-      verifyNever(databaseService.createPension(newName, newMaturityDate, null));
+      verifyNever(
+          databaseService.createPension(newName, newMaturityDate, null));
       verify(databaseService.updatePension(id, newName, newMaturityDate, null))
           .called(1);
     });
@@ -225,8 +238,12 @@ void main() {
       when(databaseService.doesPensionNameExist(null, name))
           .thenAnswer((_) async => false);
       when(databaseService.createPension(name, maturityDate, null)).thenAnswer(
-          (_) async =>
-              Pension(pensionId: 1, name: name, maturityDate: maturityDate));
+          (_) async => Pension(
+              pensionId: 1,
+              name: name,
+              maturityDate: maturityDate,
+              status: PensionStatus.active.dataValue,
+              statusDate: DateTime.now()));
 
       await tester.pumpWidget(createEditScreen(null, databaseService, true));
 
@@ -262,12 +279,17 @@ void main() {
       when(databaseService.doesPensionNameExist(id, newName))
           .thenAnswer((_) async => false);
       when(databaseService.updatePension(id, newName, maturityDate, null))
-          .thenAnswer((_) async => true);
+          .thenAnswer((_) async => 1);
 
       await tester.pumpWidget(createEditScreen(
           Pension(
-              pensionId: id, name: originalName, maturityDate: maturityDate),
-          databaseService, true));
+              pensionId: id,
+              name: originalName,
+              maturityDate: maturityDate,
+              status: PensionStatus.active.dataValue,
+              statusDate: DateTime.now()),
+          databaseService,
+          true));
 
       // Enter name into the TextFormField
       await tester.enterText(
@@ -363,9 +385,13 @@ void main() {
           .thenAnswer((_) async => true);
       when(databaseService.doesPensionNameExist(null, newName))
           .thenAnswer((_) async => false);
-      when(databaseService.createPension(newName, maturityDate, null)).thenAnswer(
-          (_) async =>
-              Pension(pensionId: 1, name: newName, maturityDate: maturityDate));
+      when(databaseService.createPension(newName, maturityDate, null))
+          .thenAnswer((_) async => Pension(
+              pensionId: 1,
+              name: newName,
+              maturityDate: maturityDate,
+              status: PensionStatus.active.dataValue,
+              statusDate: DateTime.now()));
 
       await tester.pumpWidget(createEditScreen(null, databaseService, true));
       await tester.pumpAndSettle();
@@ -394,7 +420,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text("This name is already in use"), findsNothing);
-      verify(databaseService.createPension(newName, maturityDate, null)).called(1);
+      verify(databaseService.createPension(newName, maturityDate, null))
+          .called(1);
     });
   });
 
@@ -411,7 +438,11 @@ void main() {
     testWidgets('delete button is visible for edit record', (tester) async {
       final databaseService = createMockDatabaseService();
       final pension = Pension(
-          pensionId: 1, name: 'originalName', maturityDate: DateTime.now());
+          pensionId: 1,
+          name: 'originalName',
+          maturityDate: DateTime.now(),
+          status: PensionStatus.active.dataValue,
+          statusDate: DateTime.now());
 
       await tester.pumpWidget(createEditScreen(pension, databaseService));
       await tester.pumpAndSettle();
@@ -422,7 +453,11 @@ void main() {
     testWidgets('tapping the delete button displays warning prompt',
         (tester) async {
       final pension = Pension(
-          pensionId: 1, name: 'originalName', maturityDate: DateTime.now());
+          pensionId: 1,
+          name: 'originalName',
+          maturityDate: DateTime.now(),
+          status: PensionStatus.active.dataValue,
+          statusDate: DateTime.now());
 
       await tester
           .pumpWidget(createEditScreen(pension, createMockDatabaseService()));
@@ -451,7 +486,9 @@ void main() {
       final pension = Pension(
           pensionId: pensionId,
           name: 'originalName',
-          maturityDate: DateTime.now());
+          maturityDate: DateTime.now(),
+          status: PensionStatus.active.dataValue,
+          statusDate: DateTime.now());
       final databaseService = createMockDatabaseService();
       when(databaseService.deletePension(pensionId))
           .thenAnswer((_) async => pensionId);
@@ -481,7 +518,9 @@ void main() {
       final pension = Pension(
           pensionId: pensionId,
           name: 'originalName',
-          maturityDate: DateTime.now());
+          maturityDate: DateTime.now(),
+          status: PensionStatus.active.dataValue,
+          statusDate: DateTime.now());
       final databaseService = createMockDatabaseService();
       when(databaseService.deletePension(pensionId))
           .thenAnswer((_) async => pensionId);

--- a/test/app/pension/views/edit_pension_screen_test.mocks.dart
+++ b/test/app/pension/views/edit_pension_screen_test.mocks.dart
@@ -508,7 +508,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -524,8 +524,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/pension/views/widgets/pension_data_table_test.dart
+++ b/test/app/pension/views/widgets/pension_data_table_test.dart
@@ -3,6 +3,7 @@ import 'package:pension_compare/app/home/models/pension_with_statement_model.dar
 import 'package:pension_compare/app/pension/models/pension_model.dart';
 import 'package:pension_compare/app/statement/models/statement_model.dart';
 import 'package:pension_compare/constants/chart_color_constants.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/helpers/currency_helper.dart';
 import 'package:pension_compare/app/pension/views/widgets/pension_data_table.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -47,7 +48,11 @@ void main() {
       final pensionData = [
         PensionWithStatementModel(
             pension: PensionModel(
-                pensionId: 1, name: pensionName, maturityDate: DateTime.now()),
+                pensionId: 1,
+                name: pensionName,
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
             statement: null)
       ];
 
@@ -69,7 +74,11 @@ void main() {
       final pensionData = [
         PensionWithStatementModel(
             pension: PensionModel(
-                pensionId: 1, name: pensionName, maturityDate: DateTime.now()),
+                pensionId: 1,
+                name: pensionName,
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
             statement: StatementModel(
                 statementId: 1,
                 pension: 1,
@@ -115,19 +124,25 @@ void main() {
             pension: PensionModel(
                 pensionId: pensionId1,
                 name: pensionName1,
-                maturityDate: DateTime.now()),
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
             statement: null),
         PensionWithStatementModel(
             pension: PensionModel(
                 pensionId: pensionId2,
                 name: pensionName2,
-                maturityDate: DateTime.now()),
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
             statement: null),
         PensionWithStatementModel(
             pension: PensionModel(
                 pensionId: pensionId3,
                 name: pensionName3,
-                maturityDate: DateTime.now()),
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
             statement: null)
       ];
 
@@ -163,19 +178,25 @@ void main() {
             pension: PensionModel(
                 pensionId: pensionId1,
                 name: pensionName1,
-                maturityDate: DateTime.now()),
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
             statement: null),
         PensionWithStatementModel(
             pension: PensionModel(
                 pensionId: pensionId2,
                 name: pensionName2,
-                maturityDate: DateTime.now()),
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
             statement: null),
         PensionWithStatementModel(
             pension: PensionModel(
                 pensionId: pensionId3,
                 name: pensionName3,
-                maturityDate: DateTime.now()),
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
             statement: null)
       ];
 

--- a/test/app/pension/views/widgets/pension_dropdown_test.dart
+++ b/test/app/pension/views/widgets/pension_dropdown_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mockito/annotations.dart';
 import 'package:pension_compare/app/pension/views/widgets/pension_dropdown.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -61,7 +62,9 @@ void main() {
             Pension(
                 pensionId: pensionId,
                 name: pensionName,
-                maturityDate: DateTime.now())
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
 
       await tester
@@ -93,7 +96,9 @@ void main() {
             Pension(
                 pensionId: pensionId,
                 name: pensionName,
-                maturityDate: DateTime.now())
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
 
       await tester.pumpWidget(createDropdown(
@@ -129,7 +134,9 @@ void main() {
             Pension(
                 pensionId: pensionId,
                 name: pensionName,
-                maturityDate: DateTime.now())
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       await tester.pumpWidget(createDropdown(
           databaseService, null, onSelectionChanged, onValidate));
@@ -167,7 +174,9 @@ void main() {
             Pension(
                 pensionId: pensionId,
                 name: pensionName,
-                maturityDate: DateTime.now())
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       await tester.pumpWidget(createDropdown(
           databaseService, null, onSelectionChanged, onValidate));
@@ -206,15 +215,21 @@ void main() {
             Pension(
                 pensionId: pensionId1,
                 name: pensionName1,
-                maturityDate: DateTime.now()),
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now()),
             Pension(
                 pensionId: pensionId2,
                 name: pensionName2,
-                maturityDate: DateTime.now()),
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now()),
             Pension(
                 pensionId: pensionId3,
                 name: pensionName3,
-                maturityDate: DateTime.now())
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       await tester.pumpWidget(createDropdown(
           databaseService, selectedPensionId, onSelectionChanged, onValidate));

--- a/test/app/pension/views/widgets/pension_dropdown_test.mocks.dart
+++ b/test/app/pension/views/widgets/pension_dropdown_test.mocks.dart
@@ -494,7 +494,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -510,8 +510,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/settings/controllers/secure_settings_controller_test.mocks.dart
+++ b/test/app/settings/controllers/secure_settings_controller_test.mocks.dart
@@ -494,7 +494,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -510,8 +510,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/settings/views/settings_screen_test.mocks.dart
+++ b/test/app/settings/views/settings_screen_test.mocks.dart
@@ -561,7 +561,7 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
       ) as _i6.Future<_i4.Pension?>);
 
   @override
-  _i6.Future<bool> updatePension(
+  _i6.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -577,8 +577,8 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i6.Future<int>.value(0),
+      ) as _i6.Future<int>);
 
   @override
   _i6.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/statement/controllers/statement_controller_test.mocks.dart
+++ b/test/app/statement/controllers/statement_controller_test.mocks.dart
@@ -494,7 +494,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -510,8 +510,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/app/statement/views/edit_statement_screen_test.dart
+++ b/test/app/statement/views/edit_statement_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:pension_compare/app/settings/controllers/settings_service.dart';
 import 'package:pension_compare/app/settings/models/settings.dart';
 import 'package:pension_compare/app/statement/models/statement_model.dart';
 import 'package:pension_compare/app/statement/views/edit_statement_screen.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:pension_compare/data/mapper/statement_mapper.dart';
 import 'package:pension_compare/helpers/date_helper.dart';
@@ -80,7 +81,11 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: 1, name: "new pension", maturityDate: DateTime.now())
+                pensionId: 1,
+                name: "new pension",
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       await tester.pumpWidget(createEditScreen(null, databaseService));
       await tester.pumpAndSettle();
@@ -173,10 +178,21 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
-      when(databaseService.createStatement(pensionId, statementDate, planValue,
-              projectedAnnualAmount, yearlyCharges, transferValue, paidInValue, null))
+      when(databaseService.createStatement(
+              pensionId,
+              statementDate,
+              planValue,
+              projectedAnnualAmount,
+              yearlyCharges,
+              transferValue,
+              paidInValue,
+              null))
           .thenAnswer((_) async => Statement(
               statementId: 1,
               pension: pensionId,
@@ -228,7 +244,8 @@ void main() {
               projectedAnnualAmount,
               yearlyCharges,
               transferValue,
-              paidInValue, null))
+              paidInValue,
+              null))
           .called(1);
     });
 
@@ -253,7 +270,11 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       when(databaseService.updateStatement(
               statementId,
@@ -263,7 +284,8 @@ void main() {
               newProjectedAnnualAmount,
               newYearlyCharges,
               newTransferValue,
-              newPaidInValue, null))
+              newPaidInValue,
+              null))
           .thenAnswer((_) async => true);
       when(databaseService.doesStatementDateExist(
               statementId, pensionId, newStatementDate))
@@ -313,7 +335,8 @@ void main() {
           newProjectedAnnualAmount,
           newYearlyCharges,
           newTransferValue,
-          newPaidInValue, null));
+          newPaidInValue,
+          null));
       verify(databaseService.updateStatement(
               statementId,
               pensionId,
@@ -322,7 +345,8 @@ void main() {
               newProjectedAnnualAmount,
               newYearlyCharges,
               newTransferValue,
-              newPaidInValue, null))
+              newPaidInValue,
+              null))
           .called(1);
     });
   });
@@ -344,10 +368,21 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
-      when(databaseService.createStatement(pensionId, statementDate, planValue,
-              projectedAnnualAmount, yearlyCharges, transferValue, paidInValue, null))
+      when(databaseService.createStatement(
+              pensionId,
+              statementDate,
+              planValue,
+              projectedAnnualAmount,
+              yearlyCharges,
+              transferValue,
+              paidInValue,
+              null))
           .thenAnswer((_) async => Statement(
               statementId: 1,
               pension: pensionId,
@@ -420,7 +455,11 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       when(databaseService.updateStatement(
               statementId,
@@ -430,7 +469,8 @@ void main() {
               newProjectedAnnualAmount,
               newYearlyCharges,
               newTransferValue,
-              newPaidInValue, null))
+              newPaidInValue,
+              null))
           .thenAnswer((_) async => true);
       when(databaseService.doesStatementDateExist(
               statementId, pensionId, newStatementDate))
@@ -493,10 +533,21 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
-      when(databaseService.createStatement(pensionId, statementDate, planValue,
-              projectedAnnualAmount, yearlyCharges, transferValue, paidInValue, null))
+      when(databaseService.createStatement(
+              pensionId,
+              statementDate,
+              planValue,
+              projectedAnnualAmount,
+              yearlyCharges,
+              transferValue,
+              paidInValue,
+              null))
           .thenAnswer((_) async => Statement(
               statementId: 1,
               pension: pensionId,
@@ -551,7 +602,8 @@ void main() {
           projectedAnnualAmount,
           yearlyCharges,
           transferValue,
-          paidInValue, null));
+          paidInValue,
+          null));
     });
 
     testWidgets('validation should warn of duplicate statement date',
@@ -569,10 +621,21 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
-      when(databaseService.createStatement(pensionId, statementDate, planValue,
-              projectedAnnualAmount, yearlyCharges, transferValue, paidInValue, null))
+      when(databaseService.createStatement(
+              pensionId,
+              statementDate,
+              planValue,
+              projectedAnnualAmount,
+              yearlyCharges,
+              transferValue,
+              paidInValue,
+              null))
           .thenAnswer((_) async => Statement(
               statementId: 1,
               pension: pensionId,
@@ -632,7 +695,8 @@ void main() {
           projectedAnnualAmount,
           yearlyCharges,
           transferValue,
-          paidInValue, null));
+          paidInValue,
+          null));
     });
 
     testWidgets('validation should clear after duplicate pension name',
@@ -654,7 +718,11 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       when(databaseService.createStatement(
               pensionId,
@@ -663,7 +731,8 @@ void main() {
               projectedAnnualAmount,
               yearlyCharges,
               transferValue,
-              paidInValue, null))
+              paidInValue,
+              null))
           .thenAnswer((_) async => Statement(
               statementId: 1,
               pension: pensionId,
@@ -739,7 +808,11 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
 
       await tester.pumpWidget(createEditScreen(null, databaseService));
@@ -763,7 +836,11 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       final statement = Statement(
           statementId: statementId,
@@ -797,7 +874,11 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       final statement = Statement(
           statementId: statementId,
@@ -844,7 +925,11 @@ void main() {
       final databaseService = createMockDatabaseService();
       when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
             Pension(
-                pensionId: pensionId, name: name, maturityDate: maturityDate)
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       when(databaseService.deleteStatement(statementId))
           .thenAnswer((_) async => statementId);
@@ -893,8 +978,12 @@ void main() {
       double paidInValue = 123456;
 
       final databaseService = createMockDatabaseService();
-      Pension p =
-          Pension(pensionId: pensionId, name: name, maturityDate: maturityDate);
+      Pension p = Pension(
+          pensionId: pensionId,
+          name: name,
+          maturityDate: maturityDate,
+          status: PensionStatus.active.dataValue,
+          statusDate: DateTime.now());
       when(databaseService.getAllPensions())
           .thenAnswer((_) => Stream.value([p]));
       when(databaseService.getPension(pensionId)).thenAnswer((_) async => p);

--- a/test/app/statement/views/edit_statement_screen_test.mocks.dart
+++ b/test/app/statement/views/edit_statement_screen_test.mocks.dart
@@ -508,7 +508,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -524,8 +524,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/bugfixes/issue_18_pension_overview_refresh_test.dart
+++ b/test/bugfixes/issue_18_pension_overview_refresh_test.dart
@@ -5,6 +5,7 @@ import 'package:pension_compare/app/pension/views/edit_pension_screen.dart';
 import 'package:pension_compare/app/pension/views/pension_overview_screen.dart';
 import 'package:pension_compare/app/settings/controllers/settings_service.dart';
 import 'package:pension_compare/app/settings/models/settings.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -33,7 +34,9 @@ void main() {
       DateTime maturityDate = DateTime(2024, 1, 1);
       String newName = "Record after changes";
       Pension pensionRecord =
-          Pension(pensionId: id, name: name, maturityDate: maturityDate);
+          Pension(pensionId: id, name: name, maturityDate: maturityDate,
+            status: PensionStatus.active.dataValue,
+            statusDate: DateTime.now());
 
       final databaseService = createMockDatabaseService();
       when(databaseService.watchPension(id))
@@ -43,7 +46,7 @@ void main() {
       when(databaseService.doesPensionNameExist(id, newName))
           .thenAnswer((_) async => false);
       when(databaseService.updatePension(id, newName, maturityDate, null))
-          .thenAnswer((_) async => true);
+          .thenAnswer((_) async => 1);
       when(databaseService.getAllStatementsForPension(id))
           .thenAnswer((_) => Stream.value([]));
 

--- a/test/bugfixes/issue_18_pension_overview_refresh_test.mocks.dart
+++ b/test/bugfixes/issue_18_pension_overview_refresh_test.mocks.dart
@@ -508,7 +508,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -524,8 +524,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/data/database/database_service_pension_test.dart
+++ b/test/data/database/database_service_pension_test.dart
@@ -110,10 +110,10 @@ void main() {
       final newEntry = await database.createPension(name, maturityDate, notes);
       expect(newEntry, match.isNotNull);
 
-      bool updated = await database.updatePension(
+      int updatedCount = await database.updatePension(
           newEntry!.pensionId, updatedName, updatedMaturityDate, updatedNotes);
 
-      expect(updated, isTrue);
+      expect(updatedCount, 1);
 
       final updatedEntry = await database.getPension(newEntry.pensionId);
       expect(updatedEntry, match.isNotNull);
@@ -121,6 +121,59 @@ void main() {
       expect(updatedEntry.name, updatedName);
       expect(updatedEntry.maturityDate, updatedMaturityDate);
       expect(updatedEntry.notes, updatedNotes);
+    });
+
+    test('update a pension object does not change status', () async {
+      String name = 'new pension';
+      DateTime maturityDate = DateTime(2050, 1, 1);
+      String notes = 'notes';
+      String updatedName = 'new pension';
+      DateTime updatedMaturityDate = DateTime(2050, 1, 1);
+      String updatedNotes = 'updated notes';
+
+      final newEntry = await database.createPension(name, maturityDate, notes);
+      expect(newEntry, match.isNotNull);
+
+      int updatedCount = await database.updatePension(
+          newEntry!.pensionId, updatedName, updatedMaturityDate, updatedNotes);
+
+      expect(updatedCount, 1);
+
+      final updatedEntry = await database.getPension(newEntry.pensionId);
+      expect(updatedEntry, match.isNotNull);
+      expect(updatedEntry!.status, newEntry.status);
+      expect(updatedEntry.statusDate, newEntry.statusDate);
+    });
+
+    test('update a pension object only changes intended record', () async {
+      String name1 = 'new pension 1';
+      DateTime maturityDate1 = DateTime(2050, 1, 1);
+      String notes1 = 'notes 1';
+      String name2 = 'new pension 2';
+      DateTime maturityDate2 = DateTime(2050, 2, 2);
+      String notes2 = 'notes 2';
+      String name3 = 'new pension 3';
+      DateTime maturityDate3 = DateTime(2050, 3, 3);
+      String notes3 = 'notes 3';
+      String updatedName = 'new pension';
+      DateTime updatedMaturityDate = DateTime(2050, 1, 1);
+      String updatedNotes = 'updated notes';
+
+      final newEntry1 = await database.createPension(name1, maturityDate1, notes1);
+      final newEntry2 = await database.createPension(name2, maturityDate2, notes2);
+      final newEntry3 = await database.createPension(name3, maturityDate3, notes3);
+
+      int updatedCount = await database.updatePension(
+          newEntry2!.pensionId, updatedName, updatedMaturityDate, updatedNotes);
+
+      expect(updatedCount, 1);
+
+      final notChangedEntry1 = await database.getPension(newEntry1!.pensionId);
+      final notChangedEntry3 = await database.getPension(newEntry3!.pensionId);      
+      expect(notChangedEntry1, match.isNotNull);
+      expect(notChangedEntry3, match.isNotNull);
+      expect(notChangedEntry1, newEntry1);
+      expect(notChangedEntry3, newEntry3);
     });
 
     test('delete a pension object', () async {

--- a/test/data/import_export/exporter_test.dart
+++ b/test/data/import_export/exporter_test.dart
@@ -2,6 +2,7 @@ import 'package:mockito/annotations.dart';
 import 'package:pension_compare/app/settings/models/settings.dart';
 import 'package:pension_compare/app/settings/controllers/settings_service.dart';
 import 'package:pension_compare/constants/defaults.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:pension_compare/data/import_export/exporter.dart';
 import 'package:pension_compare/data/import_export/file_formatter/json_export_file_type.dart';
@@ -26,7 +27,9 @@ void main() {
                 pensionId: 1,
                 name: 'Test Pension',
                 maturityDate: DateTime(2024, 1, 1),
-                notes: 'Some notes')
+                notes: 'Some notes',
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
           ]));
       when(databaseService.getStatePension()).thenAnswer((_) async =>
           const OtherIncome(
@@ -97,6 +100,7 @@ void main() {
       int pensionId = 1;
       String pensionName = 'Test Pension';
       DateTime maturityDate = DateTime(2024, 1, 1);
+      DateTime statusDate = DateTime.now();
       String pensionNotes = 'Some notes';
       int statementId = 5;
       DateTime statementDate = DateTime(2024, 1, 1);
@@ -123,7 +127,9 @@ void main() {
               pensionId: pensionId,
               name: pensionName,
               maturityDate: maturityDate,
-              notes: pensionNotes));
+              notes: pensionNotes,
+              status: PensionStatus.active.dataValue,
+              statusDate: statusDate));
       when(databaseService.createStatement(
               pensionId,
               statementDate,
@@ -177,6 +183,8 @@ void main() {
           name: pensionName,
           maturityDate: maturityDate,
           notes: pensionNotes,
+                status: PensionStatus.active,
+                statusDate: statusDate,
           statements: [transferStatement]);
       TransferOtherIncomeModel transferOtherIncome = TransferOtherIncomeModel(
           otherIncomeId: 1,

--- a/test/data/import_export/exporter_test.mocks.dart
+++ b/test/data/import_export/exporter_test.mocks.dart
@@ -508,7 +508,7 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.Pension?>);
 
   @override
-  _i5.Future<bool> updatePension(
+  _i5.Future<int> updatePension(
     int? id,
     String? name,
     DateTime? maturityDate,
@@ -524,8 +524,8 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
             notes,
           ],
         ),
-        returnValue: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
   _i5.Future<int> deletePension(int? id) => (super.noSuchMethod(

--- a/test/data/import_export/file_formatter/json_export_file_type_test.dart
+++ b/test/data/import_export/file_formatter/json_export_file_type_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/import_export/exporter.dart';
 import 'package:pension_compare/data/import_export/file_formatter/json_export_file_type.dart';
 import 'package:pension_compare/data/import_export/models/backup_config_model.dart';
@@ -243,6 +244,7 @@ TransferPensionModel buildPensionModel() {
   int pensionId = 5;
   String pensionName = 'new pension';
   DateTime maturityDate = DateTime(2050, 1, 1);
+  DateTime statusDate = DateTime(2024, 1, 1);
   int statementId = 5;
   DateTime statementDate = DateTime(2024, 1, 1);
   double planValue = 123.45;
@@ -263,6 +265,8 @@ TransferPensionModel buildPensionModel() {
       pensionId: pensionId,
       name: pensionName,
       maturityDate: maturityDate,
+      status: PensionStatus.active,
+      statusDate: statusDate,
       statements: [transferStatement]);
 
   return transferPension;

--- a/test/data/import_export/mapper/pension_mapper_test.dart
+++ b/test/data/import_export/mapper/pension_mapper_test.dart
@@ -1,3 +1,4 @@
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:pension_compare/data/import_export/models/transfer_pension_model.dart';
 import 'package:pension_compare/data/import_export/models/transfer_statement_model.dart';
@@ -10,6 +11,7 @@ void main() {
       int pensionId = 5;
       String pensionName = 'new pension';
       DateTime maturityDate = DateTime.now();
+      DateTime statusDate = DateTime.now();
       int statementId = 5;
       DateTime statementDate = DateTime.now();
       double planValue = 123.45;
@@ -23,7 +25,9 @@ void main() {
           pensionId: pensionId,
           name: pensionName,
           maturityDate: maturityDate,
-          notes: notes);
+          notes: notes,
+          status: PensionStatus.active.dataValue,
+          statusDate: statusDate);
       Statement statement = Statement(
           statementId: statementId,
           pension: pensionId,
@@ -42,6 +46,8 @@ void main() {
       expect(pensionModel.name, pensionName);
       expect(pensionModel.maturityDate, maturityDate);
       expect(pensionModel.notes, notes);
+      expect(pensionModel.status, PensionStatus.active);
+      expect(pensionModel.statusDate, statusDate);
       expect(pensionModel.statements, isNotNull);
       expect(pensionModel.statements.length, 1);
       expect(pensionModel.statements[0].statementId, statementId);
@@ -58,6 +64,7 @@ void main() {
       int pensionId = 5;
       String pensionName = 'new pension';
       DateTime maturityDate = DateTime.now();
+      DateTime statusDate = DateTime.now();
       int statementId = 5;
       DateTime statementDate = DateTime.now();
       double planValue = 123.45;
@@ -82,6 +89,8 @@ void main() {
           name: pensionName,
           maturityDate: maturityDate,
           notes: notes,
+          status: PensionStatus.active,
+          statusDate: statusDate,
           statements: [transferStatement]);
 
       Pension pension = PensionMapper.pensionFromTransfer(transferPension);
@@ -91,12 +100,15 @@ void main() {
       expect(pension.name, pensionName);
       expect(pension.maturityDate, maturityDate);
       expect(pension.notes, notes);
+      expect(pension.status, PensionStatus.active.dataValue);
+      expect(pension.statusDate, statusDate);
     });
 
     testWidgets('map transfer object to statement object', (tester) async {
       int pensionId = 5;
       String pensionName = 'new pension';
       DateTime maturityDate = DateTime.now();
+      DateTime statusDate = DateTime.now();
       int statementId = 5;
       DateTime statementDate = DateTime.now();
       double planValue = 123.45;
@@ -121,6 +133,8 @@ void main() {
           name: pensionName,
           maturityDate: maturityDate,
           notes: notes,
+          status: PensionStatus.active,
+          statusDate: statusDate,
           statements: [transferStatement]);
 
       List<Statement> statements =
@@ -142,6 +156,7 @@ void main() {
       int pensionId = 5;
       String pensionName = 'new pension';
       DateTime maturityDate = DateTime.now();
+      DateTime statusDate = DateTime.now();
       int statementId = 5;
       DateTime statementDate = DateTime.now();
       double planValue = 123.45;
@@ -153,7 +168,12 @@ void main() {
       String statementNotes = 'some statement notes';
 
       Pension pension = Pension(
-          pensionId: pensionId, name: pensionName, maturityDate: maturityDate, notes: notes);
+          pensionId: pensionId,
+          name: pensionName,
+          maturityDate: maturityDate,
+          notes: notes,
+          status: PensionStatus.active.dataValue,
+          statusDate: statusDate);
       Statement statement = Statement(
           statementId: statementId,
           pension: pensionId,
@@ -176,6 +196,8 @@ void main() {
       expect(resultPension.name, pension.name);
       expect(resultPension.maturityDate, pension.maturityDate);
       expect(resultPension.notes, pension.notes);
+      expect(resultPension.status, PensionStatus.active.dataValue);
+      expect(resultPension.statusDate, pension.statusDate);
       expect(resultStatements, isNotNull);
       expect(resultStatements.length, 1);
       expect(resultStatements[0].statementId, statement.statementId);

--- a/test/data/mapper/pension_mapper_test.dart
+++ b/test/data/mapper/pension_mapper_test.dart
@@ -1,4 +1,5 @@
 import 'package:pension_compare/app/pension/models/pension_model.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:pension_compare/data/mapper/pension_mapper.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,8 +10,13 @@ void main() {
       int pensionId = 5;
       String pensionName = 'new pension';
       DateTime maturityDate = DateTime.now();
+      DateTime statusDate = DateTime.now();
       Pension pension = Pension(
-          pensionId: pensionId, name: pensionName, maturityDate: maturityDate);
+          pensionId: pensionId,
+          name: pensionName,
+          maturityDate: maturityDate,
+          status: PensionStatus.active.dataValue,
+          statusDate: statusDate);
 
       PensionModel pensionModel = PensionMapper.mapToModel(pension);
 
@@ -18,14 +24,21 @@ void main() {
       expect(pensionModel.pensionId, pensionId);
       expect(pensionModel.name, pensionName);
       expect(pensionModel.maturityDate, maturityDate);
+      expect(pensionModel.status, PensionStatus.active);
+      expect(pensionModel.statusDate, statusDate);
     });
 
     testWidgets('map list object object', (tester) async {
       int pensionId = 5;
       String pensionName = 'new pension';
       DateTime maturityDate = DateTime.now();
+      DateTime statusDate = DateTime.now();
       Pension pension = Pension(
-          pensionId: pensionId, name: pensionName, maturityDate: maturityDate);
+          pensionId: pensionId,
+          name: pensionName,
+          maturityDate: maturityDate,
+          status: PensionStatus.active.dataValue,
+          statusDate: statusDate);
 
       List<PensionModel> pensionModel = PensionMapper.mapToModelList([pension]);
 
@@ -34,6 +47,8 @@ void main() {
       expect(pensionModel[0].pensionId, pensionId);
       expect(pensionModel[0].name, pensionName);
       expect(pensionModel[0].maturityDate, maturityDate);
+      expect(pensionModel[0].status, PensionStatus.active);
+      expect(pensionModel[0].statusDate, statusDate);
     });
   });
 }


### PR DESCRIPTION
add status and status date fields to pension objects.  This is currently only implemented in DB and export and not accessible view the UI