### PR TITLE
feat: show state pension on home screen charts

### DIFF
--- a/lib/app/home/views/home_screen.dart
+++ b/lib/app/home/views/home_screen.dart
@@ -2,13 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:pension_compare/app/home/controllers/pension_with_latest_statement_controller.dart';
 import 'package:pension_compare/app/home/controllers/yearly_pension_statement_controller.dart';
 import 'package:pension_compare/app/home/models/pension_with_statement_model.dart';
+import 'package:pension_compare/app/otherIncome/controllers/other_income_controller.dart';
+import 'package:pension_compare/app/otherIncome/models/other_income_model.dart';
 import 'package:pension_compare/app/pension/models/pension_model.dart';
 import 'package:pension_compare/app/pension/views/widgets/pension_data_table.dart';
 import 'package:pension_compare/app/pension/views/widgets/pension_summary_chart.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pension_compare/app/settings/controllers/secure_settings_controller.dart';
 import 'package:pension_compare/app/settings/models/secure_settings_model.dart';
+import 'package:pension_compare/app/statement/models/statement_model.dart';
 import 'package:pension_compare/constants/custom_styles.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/data/database/database_service.dart';
 import 'package:pension_compare/route_config.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -30,6 +34,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final yearlyPensionSummaryData =
         ref.watch(yearlyPensionStatementControllerProvider);
     final settingsData = ref.watch(secureSettingsControllerProvider);
+    final otherIncomeData = ref.watch(otherIncomeControllerProvider);
 
     return Scaffold(
         appBar: AppBar(title: const Text('Pension Compare'), actions: [
@@ -99,55 +104,69 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 child: Container(
                     padding: const EdgeInsets.symmetric(horizontal: 10.0),
                     child: settingsData.when(
-                      data: (settings) => yearlyPensionSummaryData.when(
-                        data: (yearlySummary) => pensionsSummaryData.when(
-                          data: (List<PensionWithStatementModel> pensions) {
-                            if (pensions.isEmpty && yearlySummary.isEmpty) {
-                              return const Center(
-                                  child: Text(
-                                      'No pensions found.  Click + to add one'));
-                            } else {
-                              return SingleChildScrollView(
-                                child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      DashboardTile(
-                                          title: 'Monthly Income',
-                                          child: GestureDetector(
-                                            onTap: () {
-                                              context
-                                                  .push(
-                                                      RouteDefs.pensionProgress)
-                                                  .then(
-                                                      (_) => {setState(() {})});
-                                            },
-                                            child: buildTargetVsActual(
-                                                pensions, settings),
-                                          )),
-                                      CustomStyles.spacerBox,
-                                      DashboardTile(
-                                          title: 'Pensions',
-                                          child: PensionDataTable(
-                                            pensionDataList: pensions,
-                                            onTap: (PensionModel pension) {
-                                              context
-                                                  .push(
-                                                      '${RouteDefs.pensionOverview}/${pension.pensionId}')
-                                                  .then(
-                                                      (_) => {setState(() {})});
-                                            },
-                                          )),
-                                      CustomStyles.spacerBox,
-                                      DashboardTile(
-                                          title: "Pension Summary",
-                                          child: PensionSummaryChart(
-                                              pensionData: pensions)),
-                                      // TODO - Add Other Income list, Warnings / Missing statements
-                                    ]),
-                              );
-                            }
-                          },
+                      data: (settings) => otherIncomeData.when(
+                        data: (otherIncomes) => yearlyPensionSummaryData.when(
+                          data: (yearlySummary) => pensionsSummaryData.when(
+                            data: (List<PensionWithStatementModel> pensions) {
+                              if (pensions.isEmpty && yearlySummary.isEmpty) {
+                                return const Center(
+                                    child: Text(
+                                        'No pensions found.  Click + to add one'));
+                              } else {
+                                return SingleChildScrollView(
+                                  child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        DashboardTile(
+                                            title: 'Monthly Income',
+                                            child: GestureDetector(
+                                              onTap: () {
+                                                context
+                                                    .push(RouteDefs
+                                                        .pensionProgress)
+                                                    .then((_) =>
+                                                        {setState(() {})});
+                                              },
+                                              child: buildTargetVsActual(
+                                                  pensions,
+                                                  otherIncomes,
+                                                  settings),
+                                            )),
+                                        CustomStyles.spacerBox,
+                                        DashboardTile(
+                                            title: 'Pensions',
+                                            child: PensionDataTable(
+                                              pensionDataList: pensions,
+                                              otherIncomeDataList: otherIncomes,
+                                              onPensionTap:
+                                                  (PensionModel pension) {
+                                                context.push(
+                                                    '${RouteDefs.pensionOverview}/${pension.pensionId}');
+                                              },
+                                              onOtherItemTap: (OtherIncomeModel
+                                                  otherIncome) {
+                                                context.push(
+                                                    RouteDefs.editStatePension);
+                                              },
+                                            )),
+                                        CustomStyles.spacerBox,
+                                        DashboardTile(
+                                            title: "Pension Summary",
+                                            child: PensionSummaryChart(
+                                                pensionData:
+                                                    addStatePensionToPensionList(
+                                                        pensions,
+                                                        otherIncomes
+                                                            .firstOrNull))),
+                                        // TODO - Add Other Income list, Warnings / Missing statements
+                                      ]),
+                                );
+                              }
+                            },
+                            loading: () => buildLoadingWidget(),
+                            error: (error, _) => buildErrorWidget(error),
+                          ),
                           loading: () => buildLoadingWidget(),
                           error: (error, _) => buildErrorWidget(error),
                         ),
@@ -173,6 +192,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   TargetVsActual buildTargetVsActual(
       List<PensionWithStatementModel> pensionData,
+      List<OtherIncomeModel> otherIncomeData,
       SecureSettingsModel? settings) {
     double projectedMonthlyValue = 0;
 
@@ -183,10 +203,38 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       }
     }
 
+    for (var otherIncomeRecord in otherIncomeData) {
+      projectedMonthlyValue += otherIncomeRecord.annualAmount / 12;
+    }
+
     return TargetVsActual(
       targetValue: settings?.targetIncome,
       actualValue: projectedMonthlyValue,
       retirementDate: settings?.retirementDate,
     );
+  }
+
+  List<PensionWithStatementModel> addStatePensionToPensionList(
+      List<PensionWithStatementModel> pensionData,
+      OtherIncomeModel? statePension) {
+    if (statePension == null) {
+      return pensionData;
+    }
+    
+    List<PensionWithStatementModel> combinedData = List.from(pensionData);
+    combinedData.add(PensionWithStatementModel(
+        pension: PensionModel(
+          pensionId: -statePension.otherIncomeId!,
+          name: statePension.name,
+          status: PensionStatus.active,
+          statusDate: DateTime.now(),
+        ),
+        statement: StatementModel(
+            pension: -statePension.otherIncomeId!,
+            statementDate: DateTime.now(),
+            planValue: 0,
+            projectedAnnualAmount: statePension.annualAmount)));
+
+    return combinedData;
   }
 }

--- a/lib/app/otherIncome/controllers/other_income_controller.dart
+++ b/lib/app/otherIncome/controllers/other_income_controller.dart
@@ -11,9 +11,10 @@ class OtherIncomeController extends _$OtherIncomeController {
       ref.read(DatabaseService.provider);
 
   @override
-  Future<List<OtherIncome>> build() {
-    // nothing to do right now
-    return Future.value([]);
+  Stream<List<OtherIncomeModel>> build() {
+    return _databaseService
+        .getAllOtherIncomes()
+        .map((p) => OtherIncomeMapper.mapToModelList(p));
   }
 
   Future<OtherIncomeModel?> getStatePension() async {

--- a/lib/app/otherIncome/controllers/other_income_controller.g.dart
+++ b/lib/app/otherIncome/controllers/other_income_controller.g.dart
@@ -7,12 +7,12 @@ part of 'other_income_controller.dart';
 // **************************************************************************
 
 String _$otherIncomeControllerHash() =>
-    r'3e1c39b813afd2e066b639ff2d5065917f30d056';
+    r'c7b01fafd39f3c5fe56a62ebc22651b60747d58c';
 
 /// See also [OtherIncomeController].
 @ProviderFor(OtherIncomeController)
-final otherIncomeControllerProvider = AutoDisposeAsyncNotifierProvider<
-    OtherIncomeController, List<OtherIncome>>.internal(
+final otherIncomeControllerProvider = AutoDisposeStreamNotifierProvider<
+    OtherIncomeController, List<OtherIncomeModel>>.internal(
   OtherIncomeController.new,
   name: r'otherIncomeControllerProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -22,6 +22,7 @@ final otherIncomeControllerProvider = AutoDisposeAsyncNotifierProvider<
   allTransitiveDependencies: null,
 );
 
-typedef _$OtherIncomeController = AutoDisposeAsyncNotifier<List<OtherIncome>>;
+typedef _$OtherIncomeController
+    = AutoDisposeStreamNotifier<List<OtherIncomeModel>>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/app/pension/views/pension_report_screen.dart
+++ b/lib/app/pension/views/pension_report_screen.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:pension_compare/app/home/controllers/yearly_pension_statement_controller.dart';
+import 'package:pension_compare/app/home/models/pension_with_statement_model.dart';
+import 'package:pension_compare/app/home/models/yearly_pension_statement_model.dart';
+import 'package:pension_compare/app/otherIncome/controllers/other_income_controller.dart';
+import 'package:pension_compare/app/otherIncome/models/other_income_model.dart';
+import 'package:pension_compare/app/pension/models/pension_model.dart';
 import 'package:pension_compare/app/pension/views/widgets/target_vs_actual_chart.dart';
 import 'package:pension_compare/app/settings/controllers/secure_settings_controller.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pension_compare/app/statement/models/statement_model.dart';
 import 'package:pension_compare/constants/custom_styles.dart';
+import 'package:pension_compare/constants/pension_status.dart';
 import 'package:pension_compare/widgets/dashboard/dashboard_tile.dart';
 
 class PensionReportScreen extends ConsumerStatefulWidget {
@@ -28,6 +35,7 @@ class _PensionReportScreenState extends ConsumerState<PensionReportScreen> {
     final settingsData = ref.watch(secureSettingsControllerProvider);
     final yearlyPensionSummaryData =
         ref.watch(yearlyPensionStatementControllerProvider);
+    final otherIncomeData = ref.watch(otherIncomeControllerProvider);
 
     return Scaffold(
         appBar: AppBar(title: const Text('Pension Performance')),
@@ -39,61 +47,70 @@ class _PensionReportScreenState extends ConsumerState<PensionReportScreen> {
                 padding: const EdgeInsets.symmetric(horizontal: 10.0),
                 child: settingsData.when(
                   data: (settings) => yearlyPensionSummaryData.when(
-                    data: (yearlySummary) {
-                      return SingleChildScrollView(
-                        child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              DashboardTile(
-                                  title: 'Projected Monthly Income',
-                                  child: TargetVsActualChart(
-                                      pensionData: yearlySummary,
-                                      retirementDate: showRetirementDate
-                                          ? settings?.retirementDate
-                                          : null,
-                                      targetValue: showTargetLine
-                                          ? settings?.targetIncome
-                                          : null,
-                                      hideTitle: true)),
-                              CustomStyles.spacerBox,
-                              if (settings?.targetIncome != null)
-                                Row(
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    const Text('Show Target Line'),
-                                    Switch.adaptive(
-                                      value: showTargetLine,
-                                      onChanged: (newValue) {
-                                        setState(() {
-                                          showTargetLine = newValue;
-                                        });
-                                      },
-                                    ),
-                                  ],
-                                ),
-                              CustomStyles.spacerBox,
-                              if (settings?.retirementDate != null)
-                                Row(
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    const Text('Show Retirement Date'),
-                                    Switch.adaptive(
-                                      value: showRetirementDate,
-                                      onChanged: (newValue) {
-                                        setState(() {
-                                          showRetirementDate = newValue;
-                                        });
-                                      },
-                                    ),
-                                  ],
-                                ),
-                            ]),
-                      );
-                    },
+                    data: (yearlySummary) => otherIncomeData.when(
+                      data: (otherIncomes) {
+                        return SingleChildScrollView(
+                          child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                DashboardTile(
+                                    title: 'Projected Monthly Income',
+                                    child: TargetVsActualChart(
+                                        pensionData:
+                                            addStatePensionToPensionList(
+                                                yearlySummary,
+                                                otherIncomes.firstOrNull),
+                                        retirementDate: showRetirementDate
+                                            ? settings.retirementDate
+                                            : null,
+                                        targetValue: showTargetLine
+                                            ? settings.targetIncome
+                                            : null,
+                                        hideTitle: true)),
+                                CustomStyles.spacerBox,
+                                if (settings.targetIncome != null)
+                                  Row(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.center,
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      const Text('Show Target Line'),
+                                      Switch.adaptive(
+                                        value: showTargetLine,
+                                        onChanged: (newValue) {
+                                          setState(() {
+                                            showTargetLine = newValue;
+                                          });
+                                        },
+                                      ),
+                                    ],
+                                  ),
+                                CustomStyles.spacerBox,
+                                if (settings.retirementDate != null)
+                                  Row(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.center,
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      const Text('Show Retirement Date'),
+                                      Switch.adaptive(
+                                        value: showRetirementDate,
+                                        onChanged: (newValue) {
+                                          setState(() {
+                                            showRetirementDate = newValue;
+                                          });
+                                        },
+                                      ),
+                                    ],
+                                  ),
+                              ]),
+                        );
+                      },
+                      loading: () => buildLoadingWidget(),
+                      error: (error, _) => buildErrorWidget(error),
+                    ),
                     loading: () => buildLoadingWidget(),
                     error: (error, _) => buildErrorWidget(error),
                   ),
@@ -110,5 +127,38 @@ class _PensionReportScreenState extends ConsumerState<PensionReportScreen> {
 
   Widget buildErrorWidget(Object error) {
     return Center(child: Text('Error loading data: $error'));
+  }
+
+  List<YearlyPensionStatementModel> addStatePensionToPensionList(
+      List<YearlyPensionStatementModel> pensionData,
+      OtherIncomeModel? statePension) {
+    if (statePension == null) {
+      return pensionData;
+    }
+
+    List<YearlyPensionStatementModel> combinedData = [];
+    for (YearlyPensionStatementModel item in pensionData) {
+      List<PensionWithStatementModel> oldList = item.pensionWithStatement;
+      List<PensionWithStatementModel> newList = List.from(oldList)
+        ..add(PensionWithStatementModel(
+            pension: PensionModel(
+              pensionId: -statePension.otherIncomeId!,
+              name: statePension.name,
+              status: PensionStatus.active,
+              statusDate: DateTime.now(),
+            ),
+            statement: StatementModel(
+                pension: -statePension.otherIncomeId!,
+                statementDate: DateTime(item.year, 1, 1),
+                planValue: 0,
+                projectedAnnualAmount: statePension.annualAmount)));
+
+      combinedData.add(YearlyPensionStatementModel(
+        year: item.year,
+        pensionWithStatement: newList,
+      ));
+    }
+
+    return combinedData;
   }
 }

--- a/lib/app/pension/views/widgets/pension_data_table.dart
+++ b/lib/app/pension/views/widgets/pension_data_table.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pension_compare/app/home/models/pension_with_statement_model.dart';
+import 'package:pension_compare/app/otherIncome/models/other_income_model.dart';
 import 'package:pension_compare/app/pension/models/pension_model.dart';
 import 'package:pension_compare/constants/chart_color_constants.dart';
 import 'package:pension_compare/constants/custom_styles.dart';
@@ -9,10 +10,17 @@ import 'package:pension_compare/service_locator.dart';
 
 class PensionDataTable extends StatefulWidget {
   final List<PensionWithStatementModel> pensionDataList;
-  final Function(PensionModel) onTap;
+  final List<OtherIncomeModel> otherIncomeDataList;
+  final Function(PensionModel) onPensionTap;
+  final Function(OtherIncomeModel) onOtherItemTap;
 
   const PensionDataTable(
-      {super.key, required this.pensionDataList, required this.onTap});
+      {super.key,
+      required this.pensionDataList,
+      required this.otherIncomeDataList,
+      required this.onPensionTap,
+      required this.onOtherItemTap
+      });
 
   @override
   State<PensionDataTable> createState() => _PensionDataTableState();
@@ -21,9 +29,7 @@ class PensionDataTable extends StatefulWidget {
 class _PensionDataTableState extends State<PensionDataTable> {
   @override
   Widget build(BuildContext context) {
-    ChartColorConstants chartColorConstants = getIt<ChartColorConstants>();
-
-    if (widget.pensionDataList.isEmpty) {
+    if (widget.pensionDataList.isEmpty ) {
       return const Center(
           child: Text('No pensions found.  Click + to add one'));
     }
@@ -31,85 +37,124 @@ class _PensionDataTableState extends State<PensionDataTable> {
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: DataTable(
-        showCheckboxColumn: false,
-        sortColumnIndex: 0,
-        columns: const <DataColumn>[
-          DataColumn(
-            label: Text(
-              'Pension',
-              style: CustomStyles.dataTableHeaderTextStyle,
+          showCheckboxColumn: false,
+          sortColumnIndex: 0,
+          columns: const <DataColumn>[
+            DataColumn(
+              label: Text(
+                'Pension',
+                style: CustomStyles.dataTableHeaderTextStyle,
+              ),
             ),
-          ),
-          DataColumn(
-            label: Text(
-              'Plan Value',
-              style: CustomStyles.dataTableHeaderTextStyle,
+            DataColumn(
+              label: Text(
+                'Plan Value',
+                style: CustomStyles.dataTableHeaderTextStyle,
+              ),
             ),
-          ),
-          DataColumn(
-            label: Text(
-              'Projected',
-              style: CustomStyles.dataTableHeaderTextStyle,
+            DataColumn(
+              label: Text(
+                'Projected',
+                style: CustomStyles.dataTableHeaderTextStyle,
+              ),
             ),
-          ),
-          DataColumn(
-            label: Text(
-              'Charges',
-              style: CustomStyles.dataTableHeaderTextStyle,
+            DataColumn(
+              label: Text(
+                'Charges',
+                style: CustomStyles.dataTableHeaderTextStyle,
+              ),
             ),
-          ),
-          DataColumn(
-            label: Text(
-              'Transfer',
-              style: CustomStyles.dataTableHeaderTextStyle,
+            DataColumn(
+              label: Text(
+                'Transfer',
+                style: CustomStyles.dataTableHeaderTextStyle,
+              ),
             ),
-          ),
-          DataColumn(
-            label: Text(
-              'Paid In',
-              style: CustomStyles.dataTableHeaderTextStyle,
+            DataColumn(
+              label: Text(
+                'Paid In',
+                style: CustomStyles.dataTableHeaderTextStyle,
+              ),
             ),
-          ),
-        ],
-        rows:
-            List<DataRow>.generate(widget.pensionDataList.length, (int index) {
-          PensionWithStatementModel pensionData = widget.pensionDataList[index];
-          return DataRow(
-            onSelectChanged: (bool? selected) =>
-                widget.onTap(pensionData.pension),
-            cells: <DataCell>[
-              DataCell(
-                  Row(
-                    children: [
-                      Container(
-                        width: 6,
-                        height: 12,
-                        decoration: BoxDecoration(
-                          color: chartColorConstants.getColorForPension(
-                              pensionData.pension.pensionId ?? 0),
-                          borderRadius: const BorderRadius.all(
-                              Radius.circular(AppDefaults.borderRadius / 3)),
-                        ),
-                      ),
-                      CustomStyles.gapW8,
-                      Text(pensionData.pension.name)
-                    ],
-                  ),
-                  onTap: () => widget.onTap(pensionData.pension)),
-              DataCell(Text(CurrencyHelper.formatCurrency(
-                  pensionData.statement?.planValue ?? 0))),
-              DataCell(Text(CurrencyHelper.formatCurrency(
-                  pensionData.statement?.projectedAnnualAmount ?? 0))),
-              DataCell(Text(CurrencyHelper.formatCurrency(
-                  pensionData.statement?.yearlyCharges ?? 0))),
-              DataCell(Text(CurrencyHelper.formatCurrency(
-                  pensionData.statement?.transferValue ?? 0))),
-              DataCell(Text(CurrencyHelper.formatCurrency(
-                  pensionData.statement?.amountPaidIn ?? 0)))
-            ],
-          );
-        }),
-      ),
+          ],
+          rows: buildDataRows()),
     );
+  }
+
+  List<DataRow> buildDataRows() {
+    ChartColorConstants chartColorConstants = getIt<ChartColorConstants>();
+
+    List<DataRow> dataRows =
+        List<DataRow>.generate(widget.pensionDataList.length, (int index) {
+      PensionWithStatementModel pensionData = widget.pensionDataList[index];
+      return DataRow(
+        onSelectChanged: (bool? selected) => widget.onPensionTap(pensionData.pension),
+        cells: <DataCell>[
+          DataCell(
+              Row(
+                children: [
+                  Container(
+                    width: 6,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      color: chartColorConstants.getColorForPension(
+                          pensionData.pension.pensionId ?? 0),
+                      borderRadius: const BorderRadius.all(
+                          Radius.circular(AppDefaults.borderRadius / 3)),
+                    ),
+                  ),
+                  CustomStyles.gapW8,
+                  Text(pensionData.pension.name)
+                ],
+              ),
+              onTap: () => widget.onPensionTap(pensionData.pension)),
+          DataCell(Text(CurrencyHelper.formatCurrency(
+              pensionData.statement?.planValue ?? 0))),
+          DataCell(Text(CurrencyHelper.formatCurrency(
+              pensionData.statement?.projectedAnnualAmount ?? 0))),
+          DataCell(Text(CurrencyHelper.formatCurrency(
+              pensionData.statement?.yearlyCharges ?? 0))),
+          DataCell(Text(CurrencyHelper.formatCurrency(
+              pensionData.statement?.transferValue ?? 0))),
+          DataCell(Text(CurrencyHelper.formatCurrency(
+              pensionData.statement?.amountPaidIn ?? 0)))
+        ],
+      );
+    });
+
+    dataRows.addAll(
+        List<DataRow>.generate(widget.otherIncomeDataList.length, (int index) {
+      OtherIncomeModel otherIncomeData = widget.otherIncomeDataList[index];
+      return DataRow(
+        onSelectChanged: (bool? selected) => widget.onOtherItemTap(otherIncomeData),
+        cells: <DataCell>[
+          DataCell(
+              Row(
+                children: [
+                  Container(
+                    width: 6,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      color: chartColorConstants.getColorForPension(-1),
+                      borderRadius: const BorderRadius.all(
+                          Radius.circular(AppDefaults.borderRadius / 3)),
+                    ),
+                  ),
+                  CustomStyles.gapW8,
+                  Text(otherIncomeData.name)
+                ],
+              ),
+              onTap: () => widget.onOtherItemTap(otherIncomeData)),
+          const DataCell(Text('')),
+          DataCell(Text(CurrencyHelper.formatCurrency(
+              otherIncomeData.annualAmount))),
+          const DataCell(Text('')),
+          const DataCell(Text('')),
+          const DataCell(Text(''))
+        ],
+      );
+    }));
+
+    return dataRows;
   }
 }

--- a/lib/app/pension/views/widgets/pension_summary_chart.dart
+++ b/lib/app/pension/views/widgets/pension_summary_chart.dart
@@ -29,6 +29,7 @@ class _PensionSummaryChartState extends State<PensionSummaryChart> {
   static const double barWidth = 30;
   Map<int, Legend> legendList = {};
   final String _currencySymbol = CurrencyHelper.getCurrencySymbol();
+  static const int pensionLabelNameLimit = 3;
 
   @override
   void initState() {
@@ -129,7 +130,9 @@ class _PensionSummaryChartState extends State<PensionSummaryChart> {
       );
 
   Widget getBottomTitles(double value, TitleMeta meta) {
-    String text = widget.pensionData![value.toInt()].pension.name;
+    String text = widget.pensionData!.length > pensionLabelNameLimit
+        ? '${widget.pensionData![value.toInt()].pension.name.substring(0, 3)}...'
+        : widget.pensionData![value.toInt()].pension.name;
 
     return SideTitleWidget(
       axisSide: meta.axisSide,

--- a/lib/app/pension/views/widgets/target_vs_actual_chart.dart
+++ b/lib/app/pension/views/widgets/target_vs_actual_chart.dart
@@ -88,7 +88,7 @@ class _TargetVsActualChartState extends State<TargetVsActualChart> {
             return BarTooltipItem(
               '${_reportData[groupIndex].pensionWithStatement[rodIndex].pension.name}\n'
               '${_reportData[groupIndex].year}\n'
-              '${CurrencyHelper.formatCurrency(rod.toY, _currencySymbol)}',
+              '${CurrencyHelper.formatCurrency(rod.toY - rod.fromY, _currencySymbol)}',
               const TextStyle(
                 color: Colors.white,
                 fontWeight: FontWeight.bold,

--- a/lib/data/database/database_service.dart
+++ b/lib/data/database/database_service.dart
@@ -233,6 +233,12 @@ class DatabaseService extends _$DatabaseService {
     return statePension;
   }
 
+  // List all the other incomes in the database
+  Stream<List<OtherIncome>> getAllOtherIncomes() {
+    return (select(otherIncomes)..orderBy([(o) => OrderingTerm.asc(o.name)]))
+        .watch();
+  }
+
   // Get the secure settings record.
   Stream<SecureSettings> getSecureSettings() {
     return (select(secureSetting)

--- a/test/app/home/controllers/pension_with_latest_statement_controller_test.mocks.dart
+++ b/test/app/home/controllers/pension_with_latest_statement_controller_test.mocks.dart
@@ -668,6 +668,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/home/controllers/yearly_pension_statement_controller_test.mocks.dart
+++ b/test/app/home/controllers/yearly_pension_statement_controller_test.mocks.dart
@@ -668,6 +668,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/home/views/home_screen_test.dart
+++ b/test/app/home/views/home_screen_test.dart
@@ -68,6 +68,9 @@ void main() {
                 targetIncome: null,
                 retirementDate: null,
               )));
+      when(databaseService.getAllOtherIncomes())
+          .thenAnswer((_) => Stream.value([]));
+
       await tester
           .pumpWidget(createHomeScreen(databaseService, mockSettingsService));
       await tester.pumpAndSettle();
@@ -102,6 +105,9 @@ void main() {
                 targetIncome: null,
                 retirementDate: null,
               )));
+      when(databaseService.getAllOtherIncomes())
+          .thenAnswer((_) => Stream.value([]));
+
       await tester
           .pumpWidget(createHomeScreen(databaseService, mockSettingsService));
       await tester.pumpAndSettle();
@@ -126,6 +132,115 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(EditPensionScreen), findsOneWidget);
+    });
+  });
+
+  group('Test displaying target vs actual widget with data', () {
+    testWidgets('show the home screen with a pension record', (tester) async {
+      int pensionId = 1;
+      String pensionName = 'new pension';
+      double planValue = 1000;
+      double projectedAnnualAmount = 1200;
+      double yearlyCharges = 100;
+      double transferValue = 500;
+
+      // Arrange
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllPensionsWithLatestStatement())
+          .thenAnswer((_) => Stream.value([
+                PensionWithStatement(
+                    Pension(
+                        pensionId: pensionId,
+                        name: pensionName,
+                        maturityDate: DateTime.now(),
+                        status: PensionStatus.active.dataValue,
+                        statusDate: DateTime.now()),
+                    Statement(
+                        statementId: 1,
+                        pension: pensionId,
+                        statementDate: DateTime.now(),
+                        planValue: planValue,
+                        projectedAnnualAmount: projectedAnnualAmount,
+                        yearlyCharges: yearlyCharges,
+                        transferValue: transferValue))
+              ]));
+      when(databaseService.getYearlyPensionSummary())
+          .thenAnswer((_) => Stream.value([]));
+      when(databaseService.getSecureSettings())
+          .thenAnswer((_) => Stream.value(const SecureSettings(
+                secureSettingsId: defaultSecureSettingsId,
+                targetIncome: 1000,
+                retirementDate: null,
+              )));
+      when(databaseService.getAllOtherIncomes())
+          .thenAnswer((_) => Stream.value([]));
+
+      // Act
+      await tester
+          .pumpWidget(createHomeScreen(databaseService, mockSettingsService));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Pension Compare"), findsOneWidget);
+
+      // Assert
+      expect(find.text('\$100'), findsOneWidget);
+      expect(find.text('Target: \$1,000'), findsOneWidget);
+    });
+
+    testWidgets(
+        'show the home screen with a pension record and state pension record',
+        (tester) async {
+      int pensionId = 1;
+      String pensionName = 'new pension';
+      double planValue = 1000;
+      double projectedAnnualAmount = 1200;
+      double yearlyCharges = 100;
+      double transferValue = 500;
+
+      // Arrange
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllPensionsWithLatestStatement())
+          .thenAnswer((_) => Stream.value([
+                PensionWithStatement(
+                    Pension(
+                        pensionId: pensionId,
+                        name: pensionName,
+                        maturityDate: DateTime.now(),
+                        status: PensionStatus.active.dataValue,
+                        statusDate: DateTime.now()),
+                    Statement(
+                        statementId: 1,
+                        pension: pensionId,
+                        statementDate: DateTime.now(),
+                        planValue: planValue,
+                        projectedAnnualAmount: projectedAnnualAmount,
+                        yearlyCharges: yearlyCharges,
+                        transferValue: transferValue))
+              ]));
+      when(databaseService.getYearlyPensionSummary())
+          .thenAnswer((_) => Stream.value([]));
+      when(databaseService.getSecureSettings())
+          .thenAnswer((_) => Stream.value(const SecureSettings(
+                secureSettingsId: defaultSecureSettingsId,
+                targetIncome: 1000,
+                retirementDate: null,
+              )));
+      when(databaseService.getAllOtherIncomes()).thenAnswer((_) =>
+          Stream.value([
+            const OtherIncome(
+                otherIncomeId: 1, name: 'State Pension', annualAmount: 1200)
+          ]));
+
+      // Act
+      await tester
+          .pumpWidget(createHomeScreen(databaseService, mockSettingsService));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Pension Compare"), findsOneWidget);
+
+      // Assert
+      expect(find.text('\$200'), findsOneWidget);
+      expect(find.text('Target: \$1,000'), findsOneWidget);
     });
   });
 }

--- a/test/app/home/views/home_screen_test.mocks.dart
+++ b/test/app/home/views/home_screen_test.mocks.dart
@@ -734,6 +734,15 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
       ) as _i6.Future<_i4.OtherIncome?>);
 
   @override
+  _i6.Stream<List<_i4.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i6.Stream<List<_i4.OtherIncome>>.empty(),
+      ) as _i6.Stream<List<_i4.OtherIncome>>);
+
+  @override
   _i6.Stream<_i4.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/home/views/welcome_screen_test.mocks.dart
+++ b/test/app/home/views/welcome_screen_test.mocks.dart
@@ -735,6 +735,15 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
       ) as _i6.Future<_i4.OtherIncome?>);
 
   @override
+  _i6.Stream<List<_i4.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i6.Stream<List<_i4.OtherIncome>>.empty(),
+      ) as _i6.Stream<List<_i4.OtherIncome>>);
+
+  @override
   _i6.Stream<_i4.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/otherIncome/controllers/other_income_controller_test.dart
+++ b/test/app/otherIncome/controllers/other_income_controller_test.dart
@@ -13,7 +13,59 @@ import 'other_income_controller_test.mocks.dart';
 @GenerateMocks([DatabaseService])
 void main() {
   group('Test other income controller', () {
-    testWidgets('get state pension records', (tester) async {
+    testWidgets('get the records', (tester) async {
+      int otherIncomeId = 1;
+      String name = 'state pension';
+      double amount = 123.45;
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllOtherIncomes()).thenAnswer((_) => Stream.value(
+          [OtherIncome(
+              otherIncomeId: otherIncomeId, name: name, annualAmount: amount)]));
+
+      final container = createContainer(overrides: [
+        DatabaseService.provider.overrideWithValue(databaseService)
+      ]);
+
+      final otherIncomeList =
+          await container.read(otherIncomeControllerProvider.future);
+
+      expect(otherIncomeList, isNotNull);
+      expect(otherIncomeList.length, 1);
+      expect(otherIncomeList[0].otherIncomeId, otherIncomeId);
+      expect(otherIncomeList[0].name, name);
+      expect(otherIncomeList[0].annualAmount, amount);
+      verify(databaseService.getAllOtherIncomes()).called(1);
+
+      // Workaround to avoid the FakeTimer error
+      // https://github.com/rrousselGit/riverpod/issues/1941
+      await tester.pumpWidget(Container());
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('get the records, handle empty dataset', (tester) async {
+      // unlikely to happen as there will always be one record for state pension, but just in case
+      final databaseService = MockDatabaseService();
+      when(databaseService.getAllOtherIncomes())
+          .thenAnswer((_) => Stream.value([]));
+
+      final container = createContainer(overrides: [
+        DatabaseService.provider.overrideWithValue(databaseService)
+      ]);
+
+      final otherIncomeList =
+          await container.read(otherIncomeControllerProvider.future);
+
+      expect(otherIncomeList, isNotNull);
+      expect(otherIncomeList.length, 0);
+      verify(databaseService.getAllOtherIncomes()).called(1);
+
+      // Workaround to avoid the FakeTimer error
+      // https://github.com/rrousselGit/riverpod/issues/1941
+      await tester.pumpWidget(Container());
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('get state pension record', (tester) async {
       int otherIncomeId = 1;
       String name = 'state pension';
       double amount = 123.45;

--- a/test/app/otherIncome/controllers/other_income_controller_test.mocks.dart
+++ b/test/app/otherIncome/controllers/other_income_controller_test.mocks.dart
@@ -668,6 +668,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/otherIncome/views/edit_state_pension_screen_test.mocks.dart
+++ b/test/app/otherIncome/views/edit_state_pension_screen_test.mocks.dart
@@ -668,6 +668,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/passcode/views/change_passcode_screen_test.mocks.dart
+++ b/test/app/passcode/views/change_passcode_screen_test.mocks.dart
@@ -827,6 +827,15 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
       ) as _i6.Future<_i4.OtherIncome?>);
 
   @override
+  _i6.Stream<List<_i4.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i6.Stream<List<_i4.OtherIncome>>.empty(),
+      ) as _i6.Stream<List<_i4.OtherIncome>>);
+
+  @override
   _i6.Stream<_i4.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/pension/controllers/pension_controller_test.mocks.dart
+++ b/test/app/pension/controllers/pension_controller_test.mocks.dart
@@ -668,6 +668,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/pension/controllers/single_pension_controller_test.mocks.dart
+++ b/test/app/pension/controllers/single_pension_controller_test.mocks.dart
@@ -668,6 +668,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/pension/views/edit_pension_screen_test.mocks.dart
+++ b/test/app/pension/views/edit_pension_screen_test.mocks.dart
@@ -682,6 +682,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/pension/views/widgets/pension_data_table_test.dart
+++ b/test/app/pension/views/widgets/pension_data_table_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pension_compare/app/home/models/pension_with_statement_model.dart';
+import 'package:pension_compare/app/otherIncome/models/other_income_model.dart';
 import 'package:pension_compare/app/pension/models/pension_model.dart';
 import 'package:pension_compare/app/statement/models/statement_model.dart';
 import 'package:pension_compare/constants/chart_color_constants.dart';
@@ -12,11 +13,18 @@ import 'package:pension_compare/service_locator.dart';
 const String key = 'pension_data_table';
 
 Widget createDataTable(
-    List<PensionWithStatementModel> pensionData, Function(PensionModel) onTap) {
+    List<PensionWithStatementModel> pensionData,
+    List<OtherIncomeModel> otherIncomeData,
+    Function(PensionModel) onPensionTap,
+    Function(OtherIncomeModel) onOtherIncomeTap) {
   getIt.registerSingleton<ChartColorConstants>(ChartColorConstants());
 
   PensionDataTable dataTable = PensionDataTable(
-      key: const Key(key), pensionDataList: pensionData, onTap: onTap);
+      key: const Key(key),
+      pensionDataList: pensionData,
+      otherIncomeDataList: otherIncomeData,
+      onPensionTap: onPensionTap,
+      onOtherItemTap: onOtherIncomeTap);
 
   return StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
     return MaterialApp(
@@ -33,7 +41,7 @@ void main() {
   });
   group('Test building datatable', () {
     testWidgets('show the widget with no pension record', (tester) async {
-      await tester.pumpWidget(createDataTable([], (_) {}));
+      await tester.pumpWidget(createDataTable([], [], (_) {}, (_) {}));
       await tester.pumpAndSettle();
 
       expect(
@@ -56,10 +64,55 @@ void main() {
             statement: null)
       ];
 
-      await tester.pumpWidget(createDataTable(pensionData, (_) {}));
+      await tester.pumpWidget(createDataTable(pensionData, [], (_) {}, (_) {}));
       await tester.pumpAndSettle();
 
       expect(find.text(pensionName), findsOneWidget);
+      expect(find.byType(DataTable), findsOneWidget);
+    });
+
+    testWidgets('show no data when other income data but no pension data',
+        (tester) async {
+      String otherIncomeName = 'new other income';
+
+      final otherIncomeData = [
+        OtherIncomeModel(
+            otherIncomeId: 1, name: otherIncomeName, annualAmount: 1000)
+      ];
+
+      await tester
+          .pumpWidget(createDataTable([], otherIncomeData, (_) {}, (_) {}));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text("No pensions found.  Click + to add one"), findsOneWidget);
+      expect(find.byType(DataTable), findsNothing);
+    });
+
+    testWidgets('show the data table with other income record', (tester) async {
+      String pensionName = 'new pension';
+      String otherIncomeName = 'new other income';
+
+      final pensionData = [
+        PensionWithStatementModel(
+            pension: PensionModel(
+                pensionId: 1,
+                name: pensionName,
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
+            statement: null)
+      ];
+      final otherIncomeData = [
+        OtherIncomeModel(
+            otherIncomeId: 1, name: otherIncomeName, annualAmount: 1000)
+      ];
+
+      await tester.pumpWidget(
+          createDataTable(pensionData, otherIncomeData, (_) {}, (_) {}));
+      await tester.pumpAndSettle();
+
+      expect(find.text(otherIncomeName), findsOneWidget);
       expect(find.byType(DataTable), findsOneWidget);
     });
 
@@ -89,7 +142,7 @@ void main() {
                 transferValue: transferValue))
       ];
 
-      await tester.pumpWidget(createDataTable(pensionData, (_) {}));
+      await tester.pumpWidget(createDataTable(pensionData, [], (_) {}, (_) {}));
       await tester.pumpAndSettle();
 
       expect(find.text(pensionName), findsOneWidget);
@@ -114,7 +167,7 @@ void main() {
       PensionModel? onTapValue;
       bool onTapCalled = false;
 
-      onTap(PensionModel value) {
+      onPensionTap(PensionModel value) {
         onTapValue = value;
         onTapCalled = true;
       }
@@ -146,7 +199,8 @@ void main() {
             statement: null)
       ];
 
-      await tester.pumpWidget(createDataTable(pensionData, onTap));
+      await tester
+          .pumpWidget(createDataTable(pensionData, [], onPensionTap, (_) {}));
       await tester.pumpAndSettle();
 
       await tester.tap(find.text(pensionName2));
@@ -154,6 +208,72 @@ void main() {
 
       expect(onTapValue, isNotNull);
       expect(onTapValue!.pensionId, equals(pensionId2));
+      expect(onTapCalled, isTrue);
+    });
+
+    testWidgets('is the other income record tappable', (tester) async {
+      int pensionId1 = 1;
+      int pensionId2 = 2;
+      int pensionId3 = 3;
+      int otherIncomeId1 = 4;
+      int otherIncomeId2 = 5;
+      int otherIncomeId3 = 6;
+      String pensionName1 = 'new pension one';
+      String pensionName2 = 'new pension two';
+      String pensionName3 = 'new pension three';
+      String otherIncomeName1 = 'other income one';
+      String otherIncomeName2 = 'other income two';
+      String otherIncomeName3 = 'other income three';
+      OtherIncomeModel? onTapValue;
+      bool onTapCalled = false;
+
+      onOtherIncomeTap(OtherIncomeModel value) {
+        onTapValue = value;
+        onTapCalled = true;
+      }
+
+      final pensionData = [
+        PensionWithStatementModel(
+            pension: PensionModel(
+                pensionId: pensionId1,
+                name: pensionName1,
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
+            statement: null),
+        PensionWithStatementModel(
+            pension: PensionModel(
+                pensionId: pensionId2,
+                name: pensionName2,
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
+            statement: null),
+        PensionWithStatementModel(
+            pension: PensionModel(
+                pensionId: pensionId3,
+                name: pensionName3,
+                maturityDate: DateTime.now(),
+                status: PensionStatus.active,
+                statusDate: DateTime.now()),
+            statement: null)
+      ];
+
+      final otherIncome = [
+        OtherIncomeModel(otherIncomeId: otherIncomeId1, name: otherIncomeName1, annualAmount: 1),
+        OtherIncomeModel(otherIncomeId: otherIncomeId2, name: otherIncomeName2, annualAmount: 2),
+        OtherIncomeModel(otherIncomeId: otherIncomeId3, name: otherIncomeName3, annualAmount: 3),
+      ];
+
+      await tester
+          .pumpWidget(createDataTable(pensionData, otherIncome, (_) {}, onOtherIncomeTap));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(otherIncomeName2));
+      await tester.pump();
+
+      expect(onTapValue, isNotNull);
+      expect(onTapValue!.otherIncomeId, equals(otherIncomeId2));
       expect(onTapCalled, isTrue);
     });
 
@@ -168,7 +288,7 @@ void main() {
       PensionModel? onTapValue;
       int onTapCalled = 0;
 
-      onTap(PensionModel value) {
+      onPensionTap(PensionModel value) {
         onTapValue = value;
         onTapCalled++;
       }
@@ -200,7 +320,8 @@ void main() {
             statement: null)
       ];
 
-      await tester.pumpWidget(createDataTable(pensionData, onTap));
+      await tester
+          .pumpWidget(createDataTable(pensionData, [], onPensionTap, (_) {}));
       await tester.pumpAndSettle();
 
       await tester.tap(find.text(pensionName2));

--- a/test/app/pension/views/widgets/pension_dropdown_test.mocks.dart
+++ b/test/app/pension/views/widgets/pension_dropdown_test.mocks.dart
@@ -668,6 +668,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/settings/controllers/secure_settings_controller_test.mocks.dart
+++ b/test/app/settings/controllers/secure_settings_controller_test.mocks.dart
@@ -668,6 +668,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/settings/views/settings_screen_test.mocks.dart
+++ b/test/app/settings/views/settings_screen_test.mocks.dart
@@ -735,6 +735,15 @@ class MockDatabaseService extends _i1.Mock implements _i4.DatabaseService {
       ) as _i6.Future<_i4.OtherIncome?>);
 
   @override
+  _i6.Stream<List<_i4.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i6.Stream<List<_i4.OtherIncome>>.empty(),
+      ) as _i6.Stream<List<_i4.OtherIncome>>);
+
+  @override
   _i6.Stream<_i4.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/statement/controllers/statement_controller_test.mocks.dart
+++ b/test/app/statement/controllers/statement_controller_test.mocks.dart
@@ -668,6 +668,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/app/statement/views/edit_statement_screen_test.mocks.dart
+++ b/test/app/statement/views/edit_statement_screen_test.mocks.dart
@@ -682,6 +682,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/bugfixes/issue_18_pension_overview_refresh_test.mocks.dart
+++ b/test/bugfixes/issue_18_pension_overview_refresh_test.mocks.dart
@@ -682,6 +682,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,

--- a/test/data/database/database_service_other_income_test.dart
+++ b/test/data/database/database_service_other_income_test.dart
@@ -1,0 +1,35 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:pension_compare/constants/defaults.dart';
+import 'package:pension_compare/data/database/database_service.dart';
+import 'package:test/test.dart';
+import 'package:matcher/matcher.dart' as match;
+
+void main() {
+  late DatabaseService database;
+
+  setUp(() {
+    final inMemory = DatabaseConnection(NativeDatabase.memory());
+    database = DatabaseService(inMemory);
+  });
+
+  tearDown(() => database.close());
+
+  group('Test list of other incomes objects', () {    
+    test('read all new pension objects', () async {
+      double amount = 123.45;
+      String notes = 'notes';
+
+      await database.saveStatePension(amount, notes);
+
+      final results = await database.getAllOtherIncomes().first;
+      expect(results, match.isNotNull);
+      expect(results.length, 1);
+      expect(results[0].otherIncomeId, defaultStatePensionId);
+      expect(results[0].name, defaultStatePensionName);
+      expect(results[0].annualAmount, amount);
+      expect(results[0].notes, notes);
+    });
+
+  });
+}

--- a/test/data/import_export/exporter_test.mocks.dart
+++ b/test/data/import_export/exporter_test.mocks.dart
@@ -682,6 +682,15 @@ class MockDatabaseService extends _i1.Mock implements _i3.DatabaseService {
       ) as _i5.Future<_i3.OtherIncome?>);
 
   @override
+  _i5.Stream<List<_i3.OtherIncome>> getAllOtherIncomes() => (super.noSuchMethod(
+        Invocation.method(
+          #getAllOtherIncomes,
+          [],
+        ),
+        returnValue: _i5.Stream<List<_i3.OtherIncome>>.empty(),
+      ) as _i5.Stream<List<_i3.OtherIncome>>);
+
+  @override
   _i5.Stream<_i3.SecureSettings> getSecureSettings() => (super.noSuchMethod(
         Invocation.method(
           #getSecureSettings,


### PR DESCRIPTION
Added state pension to home screen charts, including:
 - Target vs Actual widget
 - Pension Data table
 - Pension Summary chart
 - Pension Performance chart

Resolves #77 