### PR TITLE
feat:add explainer text to set passcode screen

### DIFF
--- a/lib/app/passcode/views/set_passcode_screen.dart
+++ b/lib/app/passcode/views/set_passcode_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pension_compare/app/passcode/controller/passcode_service.dart';
 import 'package:pension_compare/app/passcode/views/widgets/passcode_field.dart';
+import 'package:pension_compare/constants/custom_styles.dart';
 import 'package:pension_compare/extensions/material_colors.dart';
 import 'package:pension_compare/route_config.dart';
 import 'package:pension_compare/service_locator.dart';
@@ -38,7 +39,7 @@ class _SetPasscodeScreenState extends State<SetPasscodeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Enter Passcode'),
+        title: const Text('Set a Passcode'),
       ),
       body: SafeArea(
         minimum: const EdgeInsets.all(10.0),
@@ -54,10 +55,16 @@ class _SetPasscodeScreenState extends State<SetPasscodeScreen> {
                     const Text('Passcode incorrect. Please try again.',
                         style: TextStyle(color: Colors.red)),
                   const Text(
-                    'Enter your 4 to 10 digit passcode:',
+                      'To help keep your data safe, please set a passcode now.  You will need to enter this every time you start the app.'),
+                  CustomStyles.spacerBox,
+                  const Text(
+                      'You can change it at any time in the settings menu.'),
+                  CustomStyles.spacerBox,
+                  const Text(
+                    'Enter a 4 to 10 digit passcode:',
                     style: TextStyle(fontSize: 18),
                   ),
-                  const SizedBox(height: 16),
+                  CustomStyles.spacerBox,
                   SizedBox(
                       width: 200,
                       child: PasscodeField(
@@ -75,7 +82,7 @@ class _SetPasscodeScreenState extends State<SetPasscodeScreen> {
                       )),
                   const SizedBox(height: 16),
                   const Text(
-                    'Repeat your passcode:',
+                    'Repeat passcode:',
                     style: TextStyle(fontSize: 18),
                   ),
                   const SizedBox(height: 16),

--- a/lib/app/settings/views/widgets/backup_password_bottomsheet.dart
+++ b/lib/app/settings/views/widgets/backup_password_bottomsheet.dart
@@ -63,6 +63,9 @@ class _BackupPasswordBottomsheetState extends State<BackupPasswordBottomsheet> {
                 'You can secure your backup with a password. If you do, you will need to enter it when you restore your data.',
                 style: CustomStyles.infoTextStyle),
             const Text(
+                'This can be different to the passcode used to login to the app.',
+                style: CustomStyles.infoTextStyle),                
+            const Text(
                 'If you do not want to secure it, leave the fields blank.',
                 style: CustomStyles.infoTextStyle),
             //CustomStyles.spacerBox,

--- a/test/app/passcode/views/set_passcode_screen_test.dart
+++ b/test/app/passcode/views/set_passcode_screen_test.dart
@@ -58,9 +58,9 @@ void main() {
 
       // Verify that the SetPasscode widget renders correctly
       expect(find.byType(SetPasscodeScreen), findsOneWidget);
-      expect(find.text('Enter Passcode'), findsOneWidget);
-      expect(find.text('Enter your 4 to 10 digit passcode:'), findsOneWidget);
-      expect(find.text('Repeat your passcode:'), findsOneWidget);
+      expect(find.text('Set a Passcode'), findsOneWidget);
+      expect(find.text('Enter a 4 to 10 digit passcode:'), findsOneWidget);
+      expect(find.text('Repeat passcode:'), findsOneWidget);
       expect(find.byType(TextField), findsExactly(2));
       expect(find.byKey(SetPasscodeScreen.passcodeTextField), findsOneWidget);
       expect(find.byKey(SetPasscodeScreen.repeatPasscodeTextField),


### PR DESCRIPTION
Added explainer text to Set Passcode screen to explain what the passcode is for.
Refactor text on screen and added text to backup screen to explain passcode and passwords are different 