### PR TITLE
fix: settings screen now closes after restoring from backup

### DIFF
--- a/lib/app/settings/views/settings_screen.dart
+++ b/lib/app/settings/views/settings_screen.dart
@@ -100,17 +100,18 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
                       return secureSettingsData.when(
                         data: (secureSettings) {
-                          _userSettings = EditSettingsData(
-                              retirementDate: secureSettings.retirementDate,
-                              targetIncome: secureSettings.targetIncome,
-                              optIntoAnalyticsWarning:
-                                  settings.optIntoAnalyticsWarning);
-
+                          _userSettings ??= EditSettingsData(
+                                retirementDate: secureSettings.retirementDate,
+                                targetIncome: secureSettings.targetIncome,
+                                optIntoAnalyticsWarning:
+                                settings.optIntoAnalyticsWarning);
                           return EditSettingsWidget(
                               userSettings: _userSettings!,
                               onChanged: (EditSettingsData updated) {
-                                _userSettings = updated;
-                                _unsavedChanges = true;
+                                setState(() {
+                                  _userSettings = updated;
+                                  _unsavedChanges = true;
+                                });
                               });
                         },
                         loading: () => buildLoadingWidget(),
@@ -337,11 +338,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             }
 
             if (response.success) {
-              // force the screen to refresh with the new setting data
-              setState(() => {});
-
+              // Pop twice.  Once to close the restore page, once to close the settings screen
               if (!context.mounted) return;
-              Navigator.pop(context);
+              _unsavedChanges = false;
+              context.pop();
+              if (context.canPop()) {
+                context.pop();
+              }
             }
           }
         });

--- a/test/app/settings/views/settings_screen_test.dart
+++ b/test/app/settings/views/settings_screen_test.dart
@@ -48,6 +48,9 @@ Widget createSettingsScreen(SettingsService settingsService,
 
 @GenerateMocks([SettingsService, DatabaseService, AnalyticsHelper])
 void main() {
+
+  test('description', (){});
+
   setUp(() async {
     // reset before each test to prevent errors with duplicate DatabaseService
     await getIt.reset();
@@ -231,6 +234,7 @@ void main() {
       await tester.enterText(
           find.byKey(EditSettingsWidget.editSettingTargetIncomeKey),
           targetValue.toString());
+      await tester.pumpAndSettle();
 
       await tester.tap(find.byType(Switch));
       await tester.pumpAndSettle();


### PR DESCRIPTION
When restoring from backup, the settings screen is closed and the user is returned to the home screen

Resolves #84 