### PR TITLE
feature: Ensured all TextEditingControllers are disposed of correctly

### DIFF
--- a/lib/app/otherIncome/views/edit_state_pension_screen.dart
+++ b/lib/app/otherIncome/views/edit_state_pension_screen.dart
@@ -186,4 +186,11 @@ class _EditStatePensionScreenState
       ));
     }
   }
+
+  @override
+  void dispose() {
+    yearlyValueController.dispose();
+
+    super.dispose();
+  }
 }

--- a/lib/app/passcode/views/change_passcode_screen.dart
+++ b/lib/app/passcode/views/change_passcode_screen.dart
@@ -133,4 +133,13 @@ class _ChangePasscodeScreenState extends State<ChangePasscodeScreen> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    existingPasscodeController.dispose();
+    newPasscodeController.dispose();
+    repeatPasscodeController.dispose();
+
+    super.dispose();
+  }
 }

--- a/lib/app/passcode/views/enter_passcode_screen.dart
+++ b/lib/app/passcode/views/enter_passcode_screen.dart
@@ -88,4 +88,11 @@ class _EnterPasscodeScreenState extends State<EnterPasscodeScreen> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    passcodeController.dispose();
+
+    super.dispose();
+  }
 }

--- a/lib/app/passcode/views/set_passcode_screen.dart
+++ b/lib/app/passcode/views/set_passcode_screen.dart
@@ -122,4 +122,12 @@ class _SetPasscodeScreenState extends State<SetPasscodeScreen> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    passcodeController.dispose();
+    repeatPasscodeController.dispose();
+
+    super.dispose();
+  }
 }

--- a/lib/app/pension/views/edit_pension_screen.dart
+++ b/lib/app/pension/views/edit_pension_screen.dart
@@ -275,4 +275,11 @@ class _EditPensionScreenState extends ConsumerState<EditPensionScreen> {
       }
     }
   }
+
+  @override
+  void dispose() {
+    nameController.dispose();
+
+    super.dispose();
+  }
 }

--- a/lib/app/settings/views/widgets/backup_password_bottomsheet.dart
+++ b/lib/app/settings/views/widgets/backup_password_bottomsheet.dart
@@ -92,4 +92,12 @@ class _BackupPasswordBottomsheetState extends State<BackupPasswordBottomsheet> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    passwordController.dispose();
+    confirmPasswordController.dispose();
+
+    super.dispose();
+  }
 }

--- a/lib/app/settings/views/widgets/edit_settings_widget.dart
+++ b/lib/app/settings/views/widgets/edit_settings_widget.dart
@@ -96,6 +96,13 @@ class _EditSettingsWidgetState extends ConsumerState<EditSettingsWidget> {
         targetIncome: CurrencyHelper.parseCurrency(targetIncomeController.text),
         optIntoAnalyticsWarning: _optIntoAnalyticsWarning));
   }
+
+  @override
+  void dispose() {
+    targetIncomeController.dispose();
+
+    super.dispose();
+  }
 }
 
 class EditSettingsData {

--- a/lib/app/settings/views/widgets/restore_password_bottomsheet.dart
+++ b/lib/app/settings/views/widgets/restore_password_bottomsheet.dart
@@ -69,4 +69,11 @@ class _RestorePasswordBottomsheetState
       ),
     );
   }
+
+  @override
+  void dispose() {
+    passwordController.dispose();
+
+    super.dispose();
+  }
 }

--- a/lib/app/statement/views/edit_statement_screen.dart
+++ b/lib/app/statement/views/edit_statement_screen.dart
@@ -415,4 +415,15 @@ class _EditStatmentScreenState extends ConsumerState<EditStatementScreen> {
       }
     }
   }
+
+  @override
+  void dispose() {
+    planValueController.dispose();
+    projectedAnnualAmountController.dispose();
+    yearlyChargesController.dispose();
+    transferValueController.dispose();
+    paidInValueController.dispose();
+
+    super.dispose();
+  }
 }


### PR DESCRIPTION
All TextEditingControllers are now disposed, with the exception of the DateField widget, which will be addressed in issue #49 

Resolves #69 