### PR TITLE
fix: no longer able to bypass the set passcode screen

### DIFF
--- a/lib/app/home/views/welcome_screen.dart
+++ b/lib/app/home/views/welcome_screen.dart
@@ -144,7 +144,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
     getIt<SettingsService>().saveAllSettings(Settings(
       acceptTermsAndConditions: acceptTermsAndConditions,
       acceptFinancialAdviceWarning: acceptFinancialAdviceWarning,
-      welcomeScreenDismissed: true,
+      welcomeScreenDismissed: false,
       optIntoAnalyticsWarning: optIntoAnalyticsWarning,
     ));
 

--- a/lib/app/passcode/views/set_passcode_screen.dart
+++ b/lib/app/passcode/views/set_passcode_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pension_compare/app/passcode/controller/passcode_service.dart';
 import 'package:pension_compare/app/passcode/views/widgets/passcode_field.dart';
+import 'package:pension_compare/app/settings/controllers/settings_service.dart';
 import 'package:pension_compare/constants/custom_styles.dart';
 import 'package:pension_compare/extensions/material_colors.dart';
 import 'package:pension_compare/route_config.dart';
@@ -26,6 +27,7 @@ class _SetPasscodeScreenState extends State<SetPasscodeScreen> {
   void _submitPasscode() {
     if (_formKey.currentState!.validate()) {
       if (getIt<PasscodeService>().setPasscode(passcodeController.text)) {
+        getIt<SettingsService>().saveWelcomeScreenDismissed(true);
         context.go(RouteDefs.home);
       } else {
         setState(() {

--- a/lib/app/settings/controllers/settings_service.dart
+++ b/lib/app/settings/controllers/settings_service.dart
@@ -38,14 +38,19 @@ class SettingsService {
       await prefs.remove(_keyAcceptFinancialAdviceWarning);
     }
 
-    if (settings.welcomeScreenDismissed != null) {
-      await prefs.setBool(
-          _keyWelcomeScreenDismissed, settings.welcomeScreenDismissed ?? false);
+    await saveWelcomeScreenDismissed(settings.welcomeScreenDismissed, prefs);
+    await saveAnalyticsSettings(settings.optIntoAnalyticsWarning, prefs);
+  }
+
+  Future<void> saveWelcomeScreenDismissed(bool? welcomeScreenDismissed,
+      [SharedPreferences? sharedPreferences]) async {
+    final prefs = sharedPreferences ?? await SharedPreferences.getInstance();
+
+    if (welcomeScreenDismissed != null) {
+      await prefs.setBool(_keyWelcomeScreenDismissed, welcomeScreenDismissed);
     } else {
       await prefs.remove(_keyWelcomeScreenDismissed);
     }
-
-    await saveAnalyticsSettings(settings.optIntoAnalyticsWarning, prefs);
   }
 
   Future<void> saveAnalyticsSettings(bool optIntoAnalyticsWarning,

--- a/test/app/home/views/home_screen_test.mocks.dart
+++ b/test/app/home/views/home_screen_test.mocks.dart
@@ -325,6 +325,23 @@ class MockSettingsService extends _i1.Mock implements _i7.SettingsService {
       ) as _i6.Future<void>);
 
   @override
+  _i6.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i8.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
   _i6.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i8.SharedPreferences? sharedPreferences,

--- a/test/app/home/views/welcome_screen_test.dart
+++ b/test/app/home/views/welcome_screen_test.dart
@@ -166,11 +166,13 @@ void main() {
       const saveSettings = Settings(
         acceptTermsAndConditions: true,
         acceptFinancialAdviceWarning: true,
-        welcomeScreenDismissed: true,
+        welcomeScreenDismissed: false,
         optIntoAnalyticsWarning: false,
       );
       when(mockSettingsService.saveAllSettings(saveSettings))
           .thenAnswer((_) async => true);
+      when(mockSettingsService.saveWelcomeScreenDismissed(true))
+          .thenAnswer((_) async => Future<void>.value(null));          
       when(mockAnalyticsHelper.enableAnalytics(true))
           .thenAnswer((_) async => {});
 
@@ -208,11 +210,13 @@ void main() {
       const saveSettings = Settings(
         acceptTermsAndConditions: true,
         acceptFinancialAdviceWarning: true,
-        welcomeScreenDismissed: true,
+        welcomeScreenDismissed: false,
         optIntoAnalyticsWarning: true,
       );
       when(mockSettingsService.saveAllSettings(saveSettings))
           .thenAnswer((_) async => true);
+      when(mockSettingsService.saveWelcomeScreenDismissed(true))
+          .thenAnswer((_) async => Future<void>.value(null));          
       when(mockAnalyticsHelper.enableAnalytics(true))
           .thenAnswer((_) async => {});
 

--- a/test/app/home/views/welcome_screen_test.mocks.dart
+++ b/test/app/home/views/welcome_screen_test.mocks.dart
@@ -326,6 +326,23 @@ class MockSettingsService extends _i1.Mock implements _i7.SettingsService {
       ) as _i6.Future<void>);
 
   @override
+  _i6.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i8.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
   _i6.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i8.SharedPreferences? sharedPreferences,

--- a/test/app/passcode/views/change_passcode_screen_test.mocks.dart
+++ b/test/app/passcode/views/change_passcode_screen_test.mocks.dart
@@ -327,6 +327,23 @@ class MockSettingsService extends _i1.Mock implements _i7.SettingsService {
       ) as _i6.Future<void>);
 
   @override
+  _i6.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i8.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
   _i6.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i8.SharedPreferences? sharedPreferences,

--- a/test/app/passcode/views/enter_passcode_screen_test.mocks.dart
+++ b/test/app/passcode/views/enter_passcode_screen_test.mocks.dart
@@ -164,6 +164,23 @@ class MockSettingsService extends _i1.Mock implements _i7.SettingsService {
       ) as _i6.Future<void>);
 
   @override
+  _i6.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i8.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
   _i6.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i8.SharedPreferences? sharedPreferences,

--- a/test/app/passcode/views/set_passcode_screen_test.dart
+++ b/test/app/passcode/views/set_passcode_screen_test.dart
@@ -75,6 +75,8 @@ void main() {
       when(mockPasscodeService.validatePasscode(validPasscode))
           .thenAnswer((_) => true);
       when(mockPasscodeService.setPasscode(validPasscode)).thenReturn(true);
+      when(mockSettingsService.saveWelcomeScreenDismissed(true))
+          .thenAnswer((_) async => Future<void>.value(null));
 
       // Build the SetPasscode widget
       await tester.pumpWidget(
@@ -93,6 +95,7 @@ void main() {
       // Verify that the passcode is set correctly
       verify(mockPasscodeService.setPasscode(validPasscode)).called(1);
       verify(mockPasscodeService.validatePasscode(validPasscode));
+      verify(mockSettingsService.saveWelcomeScreenDismissed(true));
       expect(find.byType(SetPasscodeScreen), findsNothing);
       expect(find.byType(HomeScreen), findsOneWidget);
     });

--- a/test/app/passcode/views/set_passcode_screen_test.mocks.dart
+++ b/test/app/passcode/views/set_passcode_screen_test.mocks.dart
@@ -73,6 +73,23 @@ class MockSettingsService extends _i1.Mock implements _i3.SettingsService {
       ) as _i4.Future<void>);
 
   @override
+  _i4.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i5.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
   _i4.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i5.SharedPreferences? sharedPreferences,

--- a/test/app/pension/views/edit_pension_screen_test.mocks.dart
+++ b/test/app/pension/views/edit_pension_screen_test.mocks.dart
@@ -1284,6 +1284,23 @@ class MockSettingsService extends _i1.Mock implements _i10.SettingsService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i11.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i11.SharedPreferences? sharedPreferences,

--- a/test/app/settings/settings_service_test.dart
+++ b/test/app/settings/settings_service_test.dart
@@ -93,6 +93,33 @@ void main() {
       expect(settings.optIntoAnalyticsWarning, newOptIntoAnalyticsWarning);
     });
 
+
+    test('save the welcome screen dismissed settings does lose welcome settings', () async {
+      bool acceptTermsAndConditions = true;
+      bool acceptFinancialAdviceWarning = true;
+      bool welcomeScreenDismissed = false;
+      bool optIntoAnalyticsWarning = true;
+      bool newWelcomeScreenDismissed = true;
+
+      SharedPreferences.setMockInitialValues({
+        'acceptTermsAndConditions': acceptTermsAndConditions,
+        'acceptFinancialAdviceWarning': acceptFinancialAdviceWarning,
+        'welcomeScreenDismissed': welcomeScreenDismissed,
+        'optIntoAnalyticsWarning': optIntoAnalyticsWarning
+      });
+
+      SettingsService settingsService = SettingsService();
+      await settingsService.saveWelcomeScreenDismissed(newWelcomeScreenDismissed);
+
+      final settings = await settingsService.getAllSettings();
+      expect(settings, match.isNotNull);
+      expect(settings.acceptTermsAndConditions, acceptTermsAndConditions);
+      expect(
+          settings.acceptFinancialAdviceWarning, acceptFinancialAdviceWarning);
+      expect(settings.welcomeScreenDismissed, newWelcomeScreenDismissed);
+      expect(settings.optIntoAnalyticsWarning, optIntoAnalyticsWarning);
+    });
+
     test('save the null settings', () async {
       bool initialAcceptTermsAndConditions = true;
       bool initialAcceptFinancialAdviceWarning = true;

--- a/test/app/settings/views/settings_screen_test.mocks.dart
+++ b/test/app/settings/views/settings_screen_test.mocks.dart
@@ -326,6 +326,23 @@ class MockSettingsService extends _i1.Mock implements _i7.SettingsService {
       ) as _i6.Future<void>);
 
   @override
+  _i6.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i8.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
   _i6.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i8.SharedPreferences? sharedPreferences,

--- a/test/app/statement/views/edit_statement_screen_test.mocks.dart
+++ b/test/app/statement/views/edit_statement_screen_test.mocks.dart
@@ -1284,6 +1284,23 @@ class MockSettingsService extends _i1.Mock implements _i10.SettingsService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i11.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i11.SharedPreferences? sharedPreferences,

--- a/test/bugfixes/issue_18_pension_overview_refresh_test.mocks.dart
+++ b/test/bugfixes/issue_18_pension_overview_refresh_test.mocks.dart
@@ -1284,6 +1284,23 @@ class MockSettingsService extends _i1.Mock implements _i10.SettingsService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i11.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i11.SharedPreferences? sharedPreferences,

--- a/test/data/import_export/exporter_test.mocks.dart
+++ b/test/data/import_export/exporter_test.mocks.dart
@@ -1284,6 +1284,23 @@ class MockSettingsService extends _i1.Mock implements _i10.SettingsService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> saveWelcomeScreenDismissed(
+    bool? welcomeScreenDismissed, [
+    _i11.SharedPreferences? sharedPreferences,
+  ]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveWelcomeScreenDismissed,
+          [
+            welcomeScreenDismissed,
+            sharedPreferences,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<void> saveAnalyticsSettings(
     bool? optIntoAnalyticsWarning, [
     _i11.SharedPreferences? sharedPreferences,


### PR DESCRIPTION
If the set passcode screen is not completed and the user navigates away / closes the app, when restarting the app the welcome process is restarted.

Resolves #88 

Note: when restarting, the values of the accept terms and conditions are shown as unselected.  This is because there is currently no code to load the values from the settings, but forcing the user to re-acknowledge them is not a bad thing. May look to fix in the future.

