### PR TITLE
fix: force disable of analytics + crashlytics

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pension_compare/helpers/analytics_helper.dart';
 import 'package:pension_compare/route_config.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:pension_compare/service_locator.dart';
@@ -18,6 +19,10 @@ Future<void> main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+
+  // Force disable of the analytics collection at earliest possible time,
+  // then re enable later depending on user preferences
+  getIt<AnalyticsHelper>().enableAnalytics(false);
 
   FlutterError.onError = (errorDetails) {
     FirebaseCrashlytics.instance.recordFlutterFatalError(errorDetails);
@@ -54,7 +59,8 @@ class PensionCompareApp extends StatelessWidget {
         useMaterial3: true,
       ),
       themeMode: ThemeMode.system,
-      routerConfig: setupRouter(initialLocation: RouteDefs.loading, observers: [observer]),      
+      routerConfig: setupRouter(
+          initialLocation: RouteDefs.loading, observers: [observer]),
     );
   }
 }


### PR DESCRIPTION
All config looks correct and matches documentation [Enable opt-in reporting](https://firebase.google.com/docs/crashlytics/customize-crash-reports?platform=flutter#enable-reporting).  For now added code to disable Analytics and Crashlytics at app startup, then turn back on if the user has opted in.

Have raised issue [firebase_crashlytics: firebase_crashlytics_collection_enabled setting in AndroidManifest.xml is being ignored #13105](https://github.com/firebase/flutterfire/issues/13105) and will create a new issue to action any outcomes.

Resolves #89 