### PR TITLE
fix: prevent user entering negative values

### DIFF
--- a/lib/app/otherIncome/views/edit_state_pension_screen.dart
+++ b/lib/app/otherIncome/views/edit_state_pension_screen.dart
@@ -97,6 +97,7 @@ class _EditStatePensionScreenState
                                     statePension.annualAmount);
                             return TextFormField(
                               key: EditStatePensionScreen.yearlyValueKey,
+                              autofocus: true,
                               controller: yearlyValueController,
                               keyboardType:
                                   const TextInputType.numberWithOptions(
@@ -104,10 +105,8 @@ class _EditStatePensionScreenState
                               decoration: const InputDecoration(
                                   labelText: "Yearly Value"),
                               validator: (value) {
-                                if (value == null ||
-                                    value.isEmpty ||
-                                    CurrencyHelper.parseCurrency(value) ==
-                                        null) {
+                                if (!CurrencyHelper.validateCurrencyValue(
+                                    value)) {
                                   return "Please enter a value, or 0 if unknown";
                                 }
                                 return null;

--- a/lib/app/pension/views/edit_pension_screen.dart
+++ b/lib/app/pension/views/edit_pension_screen.dart
@@ -95,6 +95,7 @@ class _EditPensionScreenState extends ConsumerState<EditPensionScreen> {
                   children: [
                     TextFormField(
                       key: EditPensionScreen.pensionNameKey,
+                      autofocus: true,
                       controller: nameController,
                       decoration: InputDecoration(
                           labelText: "Name",

--- a/lib/app/settings/views/widgets/edit_settings_widget.dart
+++ b/lib/app/settings/views/widgets/edit_settings_widget.dart
@@ -61,10 +61,9 @@ class _EditSettingsWidgetState extends ConsumerState<EditSettingsWidget> {
             decoration:
                 const InputDecoration(labelText: "Target Monthly Income"),
             validator: (value) {
-              if (value != null && value.isNotEmpty) {
-                if (CurrencyHelper.parseCurrency(value) == null) {
-                  return "Please enter a valid number";
-                }
+              if (!CurrencyHelper.validateCurrencyValue(value,
+                  allowNull: true)) {
+                return "Please enter a valid number";
               }
               return null;
             },

--- a/lib/app/statement/views/edit_statement_screen.dart
+++ b/lib/app/statement/views/edit_statement_screen.dart
@@ -172,9 +172,7 @@ class _EditStatmentScreenState extends ConsumerState<EditStatementScreen> {
                       decoration:
                           const InputDecoration(labelText: "Plan Value"),
                       validator: (value) {
-                        if (value == null ||
-                            value.isEmpty ||
-                            CurrencyHelper.parseCurrency(value) == null) {
+                        if (!CurrencyHelper.validateCurrencyValue(value)) {
                           return "Please enter a value, or 0 if unknown";
                         }
                         return null;
@@ -192,9 +190,7 @@ class _EditStatmentScreenState extends ConsumerState<EditStatementScreen> {
                       decoration: const InputDecoration(
                           labelText: "Projected Yearly Amount"),
                       validator: (value) {
-                        if (value == null ||
-                            value.isEmpty ||
-                            CurrencyHelper.parseCurrency(value) == null) {
+                        if (!CurrencyHelper.validateCurrencyValue(value)) {
                           return "Please enter a value, or 0 if unknown";
                         }
                         return null;
@@ -212,10 +208,9 @@ class _EditStatmentScreenState extends ConsumerState<EditStatementScreen> {
                       decoration:
                           const InputDecoration(labelText: "Yearly Charges"),
                       validator: (value) {
-                        if (value != null && value.isNotEmpty) {
-                          if (CurrencyHelper.parseCurrency(value) == null) {
-                            return "Please enter a valid number";
-                          }
+                        if (!CurrencyHelper.validateCurrencyValue(value,
+                            allowNull: true)) {
+                          return "Please enter a valid number";
                         }
                         return null;
                       },
@@ -232,10 +227,9 @@ class _EditStatmentScreenState extends ConsumerState<EditStatementScreen> {
                       decoration:
                           const InputDecoration(labelText: "Transfer Value"),
                       validator: (value) {
-                        if (value != null && value.isNotEmpty) {
-                          if (CurrencyHelper.parseCurrency(value) == null) {
-                            return "Please enter a valid number";
-                          }
+                        if (!CurrencyHelper.validateCurrencyValue(value,
+                            allowNull: true)) {
+                          return "Please enter a valid number";
                         }
                         return null;
                       },
@@ -247,15 +241,14 @@ class _EditStatmentScreenState extends ConsumerState<EditStatementScreen> {
                     TextFormField(
                       key: EditStatementScreen.paidInValueKey,
                       controller: paidInValueController,
-                      keyboardType:
-                          const TextInputType.numberWithOptions(decimal: true),
+                      keyboardType: const TextInputType.numberWithOptions(
+                          decimal: true, signed: false),
                       decoration:
                           const InputDecoration(labelText: "Amount Paid In"),
                       validator: (value) {
-                        if (value != null && value.isNotEmpty) {
-                          if (CurrencyHelper.parseCurrency(value) == null) {
-                            return "Please enter a valid number";
-                          }
+                        if (!CurrencyHelper.validateCurrencyValue(value,
+                            allowNull: true)) {
+                          return "Please enter a valid number";
                         }
                         return null;
                       },

--- a/lib/helpers/currency_helper.dart
+++ b/lib/helpers/currency_helper.dart
@@ -22,4 +22,22 @@ class CurrencyHelper {
   static String getCurrencySymbol() {
     return NumberFormat.simpleCurrency().currencySymbol;
   }
+
+  static bool validateCurrencyValue(String? value,
+      {bool allowNegative = false, bool allowNull = false}) {
+    bool result = false;
+
+    if (value != null && value.isNotEmpty) {
+      double? parsedValue = double.tryParse(value);
+      result = parsedValue != null;
+
+      if (result && !allowNegative) {
+        result = parsedValue >= 0;
+      }
+    } else if (allowNull) {
+      result = true;
+    }
+
+    return result;
+  }
 }

--- a/test/app/otherIncome/views/edit_state_pension_screen_test.dart
+++ b/test/app/otherIncome/views/edit_state_pension_screen_test.dart
@@ -144,6 +144,39 @@ void main() {
 
       verifyNever(databaseService.saveStatePension(0, null));
     });
+
+    testWidgets('do not save state pension record with negative values',
+        (tester) async {
+      double initialValue = 123.45;
+      double negativeValue = -42;
+      final databaseService = MockDatabaseService();
+      when(databaseService.getStatePension()).thenAnswer((_) async =>
+          OtherIncome(
+              otherIncomeId: defaults.defaultStatePensionId,
+              name: defaults.defaultStatePensionName,
+              annualAmount: initialValue));
+      when(databaseService.saveStatePension(0, null)).thenAnswer((_) async =>
+          const OtherIncome(
+              otherIncomeId: defaults.defaultStatePensionId,
+              name: defaults.defaultStatePensionName,
+              annualAmount: 0));
+
+      await tester.pumpWidget(createEditScreen(databaseService));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.byKey(EditStatePensionScreen.yearlyValueKey), negativeValue.toString());
+
+      // Tap the save button
+      await tester.tap(find.byType(TextButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(negativeValue.toString()), findsOneWidget);
+      expect(
+          find.text("Please enter a value, or 0 if unknown"), findsOneWidget);
+
+      verifyNever(databaseService.saveStatePension(0, null));
+    });
   });
 
   group('Test url launcher to state pension site', () {

--- a/test/app/settings/views/settings_screen_test.dart
+++ b/test/app/settings/views/settings_screen_test.dart
@@ -48,8 +48,7 @@ Widget createSettingsScreen(SettingsService settingsService,
 
 @GenerateMocks([SettingsService, DatabaseService, AnalyticsHelper])
 void main() {
-
-  test('description', (){});
+  test('description', () {});
 
   setUp(() async {
     // reset before each test to prevent errors with duplicate DatabaseService
@@ -60,8 +59,8 @@ void main() {
     testWidgets('show the settings screen with no existing settings',
         (tester) async {
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(const SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          const SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: null,
               targetIncome: null)));
@@ -112,8 +111,8 @@ void main() {
       bool optIntoAnalyticsWarning = true;
 
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: retirementDate,
               targetIncome: targetValue)));
@@ -141,8 +140,8 @@ void main() {
 
     testWidgets('Set date of date picker', (WidgetTester tester) async {
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(const SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          const SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: null,
               targetIncome: null)));
@@ -196,8 +195,8 @@ void main() {
       bool optIntoAnalyticsWarning = true;
 
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: retirementDate,
               targetIncome: targetValue)));
@@ -261,8 +260,8 @@ void main() {
       bool newOptIntoAnalyticsWarning = false;
 
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: originalRetirementDate,
               targetIncome: originalTargetValue)));
@@ -326,8 +325,8 @@ void main() {
       double newTargetValue = 98765.43;
 
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: originalRetirementDate,
               targetIncome: originalTargetValue)));
@@ -380,8 +379,8 @@ void main() {
     testWidgets('validation should allow empty values to remain',
         (tester) async {
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(const SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          const SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: null,
               targetIncome: null)));
@@ -420,8 +419,8 @@ void main() {
         (tester) async {
       double targetValue = 12345.0;
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: null,
               targetIncome: targetValue)));
@@ -467,8 +466,8 @@ void main() {
       DateTime retirementDate = DateHelper.getToday();
       String invalidTargetValue = 'invalid';
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(const SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          const SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: null,
               targetIncome: null)));
@@ -516,6 +515,61 @@ void main() {
       verifyNever(settingsService.saveAnalyticsSettings(false));
       verifyNever(databaseService.saveSecureSettings(null, retirementDate));
     });
+
+    testWidgets('validation should prevent negative target income value',
+        (tester) async {
+      DateTime retirementDate = DateHelper.getToday();
+      double negativeTargetValue = -42;
+      final databaseService = MockDatabaseService();
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          const SecureSettings(
+              secureSettingsId: defaultSecureSettingsId,
+              retirementDate: null,
+              targetIncome: null)));
+      when(databaseService.saveSecureSettings(null, retirementDate)).thenAnswer(
+          (_) async => Future.value(SecureSettings(
+              secureSettingsId: defaultSecureSettingsId,
+              retirementDate: retirementDate,
+              targetIncome: null)));
+      final settingsService = MockSettingsService();
+      when(settingsService.getAllSettings()).thenAnswer((_) async =>
+          const Settings(
+              acceptTermsAndConditions: null,
+              acceptFinancialAdviceWarning: null,
+              welcomeScreenDismissed: null,
+              optIntoAnalyticsWarning: false));
+      when(settingsService.saveAnalyticsSettings(false))
+          .thenAnswer((_) async => true);
+      final mockAnalyticsHelper = MockAnalyticsHelper();
+      when(mockAnalyticsHelper.enableAnalytics(false))
+          .thenAnswer((_) async => {});
+
+      await tester.pumpWidget(createSettingsScreen(
+          settingsService, databaseService, mockAnalyticsHelper));
+      await tester.pumpAndSettle();
+
+      // Set the date of the date picker
+      await tester
+          .tap(find.byKey(EditSettingsWidget.editSettingRetirementDateKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(retirementDate.day.toString()));
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.byKey(EditSettingsWidget.editSettingTargetIncomeKey),
+          negativeTargetValue.toString());
+
+      // Tap the save button
+      await tester.tap(find.widgetWithText(TextButton, "Save"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Please enter a valid number"), findsOneWidget);
+
+      verify(settingsService.getAllSettings()).called(1);
+      verifyNever(settingsService.saveAnalyticsSettings(false));
+      verifyNever(databaseService.saveSecureSettings(null, retirementDate));
+    });
   });
 
   group('Test delete all button', () {
@@ -529,8 +583,8 @@ void main() {
               welcomeScreenDismissed: null,
               optIntoAnalyticsWarning: false));
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(const SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          const SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: null,
               targetIncome: null)));
@@ -565,8 +619,8 @@ void main() {
               welcomeScreenDismissed: null,
               optIntoAnalyticsWarning: false));
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(const SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          const SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: null,
               targetIncome: null)));
@@ -603,8 +657,8 @@ void main() {
               welcomeScreenDismissed: null,
               optIntoAnalyticsWarning: false));
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(const SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          const SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: null,
               targetIncome: null)));
@@ -645,8 +699,8 @@ void main() {
       bool optIntoAnalyticsWarning = true;
 
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: retirementDate,
               targetIncome: targetValue)));
@@ -693,7 +747,7 @@ void main() {
           .called(1);
       verify(mockAnalyticsHelper.enableAnalytics(true)).called(1);
       verify(databaseService.saveSecureSettings(targetValue, retirementDate))
-          .called(1);          
+          .called(1);
     });
 
     testWidgets(
@@ -703,8 +757,8 @@ void main() {
       double targetValue = 12345.0;
       bool optIntoAnalyticsWarning = false;
       final databaseService = MockDatabaseService();
-      when(databaseService.getSecureSettings()).thenAnswer((_) =>
-          Stream.value(SecureSettings(
+      when(databaseService.getSecureSettings()).thenAnswer((_) => Stream.value(
+          SecureSettings(
               secureSettingsId: defaultSecureSettingsId,
               retirementDate: retirementDate,
               targetIncome: targetValue)));

--- a/test/app/statement/views/edit_statement_screen_test.dart
+++ b/test/app/statement/views/edit_statement_screen_test.dart
@@ -606,6 +606,94 @@ void main() {
           null));
     });
 
+    testWidgets('validation should prevent negative values', (tester) async {
+      String name = "Test Pension";
+      DateTime maturityDate = DateHelper.getToday();
+      int pensionId = 1;
+      DateTime statementDate = DateHelper.getToday();
+      double planValue = 12345.0;
+      double projectedAnnualAmount = 1234;
+      double yearlyCharges = 100;
+      double transferValue = 12345;
+      double paidInValue = 123456;
+      double negNumber = -42;
+
+      final databaseService = createMockDatabaseService();
+      when(databaseService.getAllPensions()).thenAnswer((_) => Stream.value([
+            Pension(
+                pensionId: pensionId,
+                name: name,
+                maturityDate: maturityDate,
+                status: PensionStatus.active.dataValue,
+                statusDate: DateTime.now())
+          ]));
+      when(databaseService.createStatement(
+              pensionId,
+              statementDate,
+              planValue,
+              projectedAnnualAmount,
+              yearlyCharges,
+              transferValue,
+              paidInValue,
+              null))
+          .thenAnswer((_) async => Statement(
+              statementId: 1,
+              pension: pensionId,
+              statementDate: statementDate,
+              planValue: planValue,
+              projectedAnnualAmount: projectedAnnualAmount,
+              yearlyCharges: yearlyCharges,
+              transferValue: transferValue,
+              amountPaidIn: paidInValue));
+      when(databaseService.doesStatementDateExist(
+              null, pensionId, statementDate))
+          .thenAnswer((_) async => false);
+
+      await tester.pumpWidget(createEditScreen(null, databaseService));
+      await tester.pumpAndSettle();
+
+      // select the pension from the DropDownButtonFormField
+      await tester.tap(find.byKey(EditStatementScreen.pensionKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(DropdownMenuItem<int>, name).last);
+      await tester.pumpAndSettle();
+
+      // Set the date of the date picker
+      await tester.tap(find.byKey(EditStatementScreen.statementDateKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(statementDate.day.toString()));
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.byKey(EditStatementScreen.planValueKey), negNumber.toString());
+      await tester.enterText(
+          find.byKey(EditStatementScreen.projectedAnnualAmountKey),
+          negNumber.toString());
+      await tester.enterText(find.byKey(EditStatementScreen.yearlyChargesKey),
+          negNumber.toString());
+      await tester.enterText(find.byKey(EditStatementScreen.transferValueKey),
+          negNumber.toString());
+      await tester.enterText(
+          find.byKey(EditStatementScreen.paidInValueKey), negNumber.toString());
+      // Tap the save button
+      await tester.tap(find.widgetWithText(TextButton, 'Save'));
+
+      expect(
+          find.text("Please enter a value, or 0 if unknown"), findsNWidgets(2));
+
+      verify(databaseService.getAllPensions()).called(1);
+      verifyNever(databaseService.createStatement(
+          pensionId,
+          statementDate,
+          planValue,
+          projectedAnnualAmount,
+          yearlyCharges,
+          transferValue,
+          paidInValue,
+          null));
+    });
+
     testWidgets('validation should warn of duplicate statement date',
         (tester) async {
       String name = "Test Pension";


### PR DESCRIPTION
Fixed issue where user could enter negative values in Edit Pension, Edit Statement and Settings screens.

Also set auto focus on initial input fields on above screens where applicable.

Resolves #67 