### PR TITLE
chore:fix-sdk-version-for-github-action-tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.22.3'
 
       - name: Flutter Version
         run: flutter --version


### PR DESCRIPTION
Fix the Flutter SDK version to 3.22.3 for now to allow Github action tests to run.  Will revert back to using the latest after release