### PR TITLE
bug: incorrect currency code showing

### DIFF
--- a/lib/helpers/currency_helper.dart
+++ b/lib/helpers/currency_helper.dart
@@ -1,12 +1,18 @@
 import 'package:intl/intl.dart';
+import 'dart:io';
 
 class CurrencyHelper {
+  static String getLocale() {
+    return Platform.localeName;
+  }
+
   static String formatCurrency(double? value, [String currencySymbol = '']) {
     if (value == null) {
       return '';
     }
 
-    return NumberFormat.currency(locale: 'en_GB', symbol: currencySymbol)
+    return NumberFormat.currency(
+            locale: CurrencyHelper.getLocale(), symbol: currencySymbol)
         .format(value);
   }
 
@@ -20,7 +26,8 @@ class CurrencyHelper {
   }
 
   static String getCurrencySymbol() {
-    return NumberFormat.simpleCurrency().currencySymbol;
+    return NumberFormat.simpleCurrency(locale: CurrencyHelper.getLocale())
+        .currencySymbol;
   }
 
   static bool validateCurrencyValue(String? value,


### PR DESCRIPTION
Currency code was always defaulting to USD ($).  Now read from platform object.

Resolves #117 