### PR TITLE
fix:extended number validation to handle commas

### DIFF
--- a/lib/helpers/currency_helper.dart
+++ b/lib/helpers/currency_helper.dart
@@ -35,7 +35,7 @@ class CurrencyHelper {
     bool result = false;
 
     if (value != null && value.isNotEmpty) {
-      double? parsedValue = double.tryParse(value);
+      double? parsedValue = parseCurrency(value);
       result = parsedValue != null;
 
       if (result && !allowNegative) {

--- a/test/helpers/currency_helper_test.dart
+++ b/test/helpers/currency_helper_test.dart
@@ -99,4 +99,106 @@ void main() {
       expect(parsedValue, null);
     });
   });
+
+  group('Test validating currency values', () {
+    test('validate currency with decimal point', () {
+      String value = "1234.56";
+
+      bool result = CurrencyHelper.validateCurrencyValue(value);
+
+      expect(result, true);
+    });
+
+    test('validate currency with no decimal point', () {
+      String value = "1234";
+
+      bool result = CurrencyHelper.validateCurrencyValue(value);
+
+      expect(result, true);
+    });
+
+    test('validate currency with no value', () {
+      String value = "";
+
+      bool result = CurrencyHelper.validateCurrencyValue(value);
+
+      expect(result, false);
+    });
+
+    test('validate currency with null value', () {
+      String? value;
+
+      bool result = CurrencyHelper.validateCurrencyValue(value);
+
+      expect(result, false);
+    });
+
+    test('validate currency with no value when nulls are allowed', () {
+      String value = "";
+
+      bool result =
+          CurrencyHelper.validateCurrencyValue(value, allowNull: true);
+
+      expect(result, true);
+    });
+
+    test('validate currency with null value when nulls are allowed', () {
+      String? value;
+
+      bool result =
+          CurrencyHelper.validateCurrencyValue(value, allowNull: true);
+
+      expect(result, true);
+    });
+
+    test('validate currency with zero value', () {
+      String value = "0";
+
+      bool result = CurrencyHelper.validateCurrencyValue(value);
+
+      expect(result, true);
+    });
+
+    test('validate currency with zero value with decimal point', () {
+      String value = "0.00";
+
+      bool result = CurrencyHelper.validateCurrencyValue(value);
+
+      expect(result, true);
+    });
+
+    test('validate currency with negative value', () {
+      String value = "-1234";
+
+      bool result = CurrencyHelper.validateCurrencyValue(value);
+
+      expect(result, false);
+    });
+
+    test('validate currency with negative value when negatives are allowed',
+        () {
+      String value = "-1234";
+
+      bool result =
+          CurrencyHelper.validateCurrencyValue(value, allowNegative: true);
+
+      expect(result, true);
+    });
+
+    test('validate currency with invalid value', () {
+      String value = "invalid";
+
+      bool result = CurrencyHelper.validateCurrencyValue(value);
+
+      expect(result, false);
+    });
+
+    test('validate currency with decimal point and comma', () {
+      String value = "1,234.56";
+
+      bool result = CurrencyHelper.validateCurrencyValue(value);
+
+      expect(result, true);
+    });
+  });
 }


### PR DESCRIPTION
Number validation was previously failing if the number had a comma in it (i.e. 1,000.00).  Fixed validation to handle this.