### PR TITLE
feat: Dashboard title to use app icon green

### DIFF
--- a/lib/constants/custom_styles.dart
+++ b/lib/constants/custom_styles.dart
@@ -43,5 +43,5 @@ class CustomStyles {
   static const gapW16 = SizedBox(width: 16);
 //  static const gapW24 = SizedBox(width: 24);
 
+  static const appIconGreenColor = Color(0xff4CAF50);
 }
-

--- a/lib/widgets/dashboard/dashboard_title.dart
+++ b/lib/widgets/dashboard/dashboard_title.dart
@@ -1,8 +1,6 @@
 import 'package:pension_compare/helpers/responsive.dart';
 import 'package:flutter/material.dart';
-import 'package:pension_compare/constants/defaults.dart';
 import 'package:pension_compare/constants/custom_styles.dart';
-import 'package:pension_compare/extensions/material_colors.dart';
 
 class DashboardTitle extends StatelessWidget {
   const DashboardTitle({
@@ -22,9 +20,8 @@ class DashboardTitle extends StatelessWidget {
           width: 12,
           height: 24,
           decoration: BoxDecoration(
-            color: color ?? context.primary,
-            borderRadius: const BorderRadius.all(
-                Radius.circular(AppDefaults.borderRadius / 3)),
+            color: color ?? CustomStyles.appIconGreenColor,
+            shape: BoxShape.circle,
           ),
         ),
         CustomStyles.gapW8,


### PR DESCRIPTION
Changed the dashboard title "tab" image to use a green circle, the same green as used in the app icon and branding

Resolves #115 