### PR TITLE
chore: update gitignore to remove crashlytics debug symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Firebase Crashlytics symbols
+.crashlytics


### PR DESCRIPTION
After completing issue #52, Crashlytics debug symbols were added to the project.  As advised [here](https://stackoverflow.com/questions/22460058/how-is-a-dsym-file-created) these should not be under source control so updating the .gitignore file to reflect this