### PR TITLE
feat: Allow tapping switch label to replicate tapping switch

### DIFF
--- a/lib/app/home/views/welcome_screen.dart
+++ b/lib/app/home/views/welcome_screen.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:pension_compare/route_config.dart';
 import 'package:pension_compare/service_locator.dart';
 import 'package:pension_compare/widgets/analytics_opt_in.dart';
+import 'package:pension_compare/widgets/custom_switch.dart';
 
 class WelcomeScreen extends StatefulWidget {
   static const welcomeAcceptTermsAndConditionsKey =
@@ -68,42 +69,29 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                           extra: PolicyType.privacyPolicy);
                     }),
                     CustomStyles.spacerBox,
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        const Text('I accept the terms and conditions'),
-                        Switch.adaptive(
-                            key: WelcomeScreen
-                                .welcomeAcceptTermsAndConditionsKey,
-                            value: acceptTermsAndConditions,
-                            onChanged: (newValue) {
-                              setState(() {
-                                acceptTermsAndConditions = newValue;
-                              });
-                            }),
-                      ],
-                    ),
+                    CustomSwitch(
+                        key: WelcomeScreen.welcomeAcceptTermsAndConditionsKey,
+                        labelText: 'I accept the terms and conditions',
+                        switchValue: acceptTermsAndConditions,
+                        onChanged: (newValue) {
+                          setState(() {
+                            acceptTermsAndConditions = newValue;
+                          });
+                        }),
                     CustomStyles.spacerBox,
                     const Text(
                         'The information provided is for illustrative purposes only and should not be considered financial advice. Please consult a financial advisor before making any financial decisions.'),
                     CustomStyles.spacerBox,
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        const Text('I agree'),
-                        Switch.adaptive(
-                            key: WelcomeScreen
-                                .welcomeAcceptFinanicalAdviceWarningKey,
-                            value: acceptFinancialAdviceWarning,
-                            onChanged: (newValue) {
-                              setState(() {
-                                acceptFinancialAdviceWarning = newValue;
-                              });
-                            }),
-                      ],
-                    ),
+                    CustomSwitch(
+                        key: WelcomeScreen
+                            .welcomeAcceptFinanicalAdviceWarningKey,
+                        labelText: 'I agree',
+                        switchValue: acceptFinancialAdviceWarning,
+                        onChanged: (newValue) {
+                          setState(() {
+                            acceptFinancialAdviceWarning = newValue;
+                          });
+                        }),
                     CustomStyles.spacerBox,
                     AnalyticsOptIn(
                       key: WelcomeScreen.welcomeOptIntoAnalyticsKey,

--- a/lib/app/pension/views/pension_report_screen.dart
+++ b/lib/app/pension/views/pension_report_screen.dart
@@ -11,6 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pension_compare/app/statement/models/statement_model.dart';
 import 'package:pension_compare/constants/custom_styles.dart';
 import 'package:pension_compare/constants/pension_status.dart';
+import 'package:pension_compare/widgets/custom_switch.dart';
 import 'package:pension_compare/widgets/dashboard/dashboard_tile.dart';
 
 class PensionReportScreen extends ConsumerStatefulWidget {
@@ -66,39 +67,25 @@ class _PensionReportScreenState extends ConsumerState<PensionReportScreen> {
                                       hideTitle: true)),
                               CustomStyles.spacerBox,
                               if (settings.targetIncome != null)
-                                Row(
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    const Text('Show Target Line'),
-                                    Switch.adaptive(
-                                      value: showTargetLine,
-                                      onChanged: (newValue) {
-                                        setState(() {
-                                          showTargetLine = newValue;
-                                        });
-                                      },
-                                    ),
-                                  ],
+                                CustomSwitch(
+                                  labelText: 'Show Target Line',
+                                  switchValue: showTargetLine,
+                                  onChanged: (newValue) {
+                                    setState(() {
+                                      showTargetLine = newValue;
+                                    });
+                                  },
                                 ),
                               CustomStyles.spacerBox,
                               if (settings.retirementDate != null)
-                                Row(
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    const Text('Show Retirement Date'),
-                                    Switch.adaptive(
-                                      value: showRetirementDate,
-                                      onChanged: (newValue) {
-                                        setState(() {
-                                          showRetirementDate = newValue;
-                                        });
-                                      },
-                                    ),
-                                  ],
+                                CustomSwitch(
+                                  labelText: 'Show Retirement Date',
+                                  switchValue: showRetirementDate,
+                                  onChanged: (newValue) {
+                                    setState(() {
+                                      showRetirementDate = newValue;
+                                    });
+                                  },
                                 ),
                             ]),
                       );

--- a/lib/widgets/analytics_opt_in.dart
+++ b/lib/widgets/analytics_opt_in.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pension_compare/constants/custom_styles.dart';
+import 'package:pension_compare/widgets/custom_switch.dart';
 
 class AnalyticsOptIn extends StatelessWidget {
   final bool optIntoAnalyticsValue;
@@ -18,18 +19,12 @@ class AnalyticsOptIn extends StatelessWidget {
           const Text(
               'I agree for analytics and crash data to be sent to Google to help improve this application'),
           CustomStyles.spacerBox,
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              const Text('I agree'),
-              Switch.adaptive(
-                key: Key('${key.toString()}_switch'),
-                value: optIntoAnalyticsValue,
-                onChanged: onChanged,
-              ),
-            ],
-          ),
+          CustomSwitch(
+            key: key,
+            labelText: 'I agree',
+            onChanged: onChanged,
+            switchValue: optIntoAnalyticsValue,
+          )
         ]);
   }
 }

--- a/lib/widgets/custom_switch.dart
+++ b/lib/widgets/custom_switch.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class CustomSwitch extends StatelessWidget {
+  final String? labelText;
+  final bool switchValue;
+  final Function(bool value)? onChanged;
+
+  const CustomSwitch(
+      {super.key, this.labelText, this.onChanged, this.switchValue = true});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        GestureDetector(
+          onTap: () {
+            onChanged!(!switchValue);
+          },
+          child: Text(
+            labelText ?? '',
+            key: Key('${key.toString()}_label'),
+          ),
+        ),
+        Switch.adaptive(
+          key: Key('${key.toString()}_switch'),
+          value: switchValue,
+          onChanged: onChanged,          
+        ),
+      ],
+    );
+  }
+}

--- a/test/app/home/views/welcome_screen_test.dart
+++ b/test/app/home/views/welcome_screen_test.dart
@@ -181,11 +181,11 @@ void main() {
 
       // accept financial advice warning and terms and conditions
       await tester
-          .tap(find.byKey(WelcomeScreen.welcomeAcceptTermsAndConditionsKey));
+          .tap(find.byKey(Key('${WelcomeScreen.welcomeAcceptTermsAndConditionsKey.toString()}_switch')));
       await tester.pumpAndSettle();
 
       await tester.tap(
-          find.byKey(WelcomeScreen.welcomeAcceptFinanicalAdviceWarningKey));
+          find.byKey(Key('${WelcomeScreen.welcomeAcceptFinanicalAdviceWarningKey.toString()}_switch')));
       await tester.pumpAndSettle();
 
       // Tap the continue button without accepting terms
@@ -225,11 +225,11 @@ void main() {
 
       // accept financial advice warning and terms and conditions
       await tester
-          .tap(find.byKey(WelcomeScreen.welcomeAcceptTermsAndConditionsKey));
+          .tap(find.byKey(Key('${WelcomeScreen.welcomeAcceptTermsAndConditionsKey.toString()}_switch')));
       await tester.pumpAndSettle();
 
       await tester.tap(
-          find.byKey(WelcomeScreen.welcomeAcceptFinanicalAdviceWarningKey));
+          find.byKey(Key('${WelcomeScreen.welcomeAcceptFinanicalAdviceWarningKey.toString()}_switch')));
       await tester.pumpAndSettle();
 
       final optIntoAnalyticsFinder = find.byKey(

--- a/test/widgets/custom_switch_test.dart
+++ b/test/widgets/custom_switch_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pension_compare/widgets/custom_switch.dart';
+
+const key = Key('custom_switch_field');
+final _formKey = GlobalKey<FormState>();
+
+Widget createSwitch(
+    String labelText, Function(bool) onChanged, bool switchValue) {
+  CustomSwitch customSwitch = CustomSwitch(
+      key: key,
+      labelText: labelText,
+      onChanged: onChanged,
+      switchValue: switchValue);
+
+  return StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+    return MaterialApp(
+        home: Scaffold(
+            body: Form(
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                key: _formKey,
+                child: customSwitch)));
+  });
+}
+
+void main() {
+  group('Test building widget', () {
+    testWidgets('show the widget with initial true value', (tester) async {
+      String label = 'test switch field';
+      await tester.pumpWidget(createSwitch(label, (_) {}, true));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel(label), findsOneWidget);
+    });
+
+    testWidgets('show the widget with initial false value', (tester) async {
+      String label = 'test switch field';
+      await tester.pumpWidget(createSwitch(label, (_) {}, false));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel(label), findsOneWidget);
+    });
+
+    testWidgets(
+        'Given the custom switch widget, When tapping the switch widget the value changed',
+        (tester) async {
+      String label = 'test switch field';
+      bool initialValue = true;
+      bool? onSelectionChangedValue;
+      bool onSelectionChangedCalled = false;
+
+      onSelectionChanged(bool value) {
+        onSelectionChangedValue = value;
+        onSelectionChangedCalled = true;
+      }
+
+      await tester
+          .pumpWidget(createSwitch(label, onSelectionChanged, initialValue));
+
+      // Tap on the switch to change the value
+      await tester.tap(find.byKey(Key('${key.toString()}_switch')));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel(label), findsOneWidget);
+      expect(onSelectionChangedValue, isFalse);
+      expect(onSelectionChangedCalled, isTrue);
+    });
+
+    testWidgets(
+        'Given the custom switch widget, When tapping the label widget the value changed',
+        (tester) async {
+      String label = 'test switch field';
+      bool initialValue = true;
+      bool? onSelectionChangedValue;
+      bool onSelectionChangedCalled = false;
+
+      onSelectionChanged(bool value) {
+        onSelectionChangedValue = value;
+        onSelectionChangedCalled = true;
+      }
+
+      await tester
+          .pumpWidget(createSwitch(label, onSelectionChanged, initialValue));
+
+      // Tap on the switch to change the value
+      await tester.tap(find.byKey(Key('${key.toString()}_label')));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel(label), findsOneWidget);
+      expect(onSelectionChangedValue, isFalse);
+      expect(onSelectionChangedCalled, isTrue);
+    });
+
+    testWidgets(
+        'Given the custom switch widget, When tapping the text the value changed',
+        (tester) async {
+      String label = 'test switch field';
+      bool initialValue = true;
+      bool? onSelectionChangedValue;
+      bool onSelectionChangedCalled = false;
+
+      onSelectionChanged(bool value) {
+        onSelectionChangedValue = value;
+        onSelectionChangedCalled = true;
+      }
+
+      await tester
+          .pumpWidget(createSwitch(label, onSelectionChanged, initialValue));
+
+      // Tap on the switch to change the value
+      await tester.tap(find.text(label));
+      await tester.pumpAndSettle();
+
+      expect(onSelectionChangedValue, isFalse);
+      expect(onSelectionChangedCalled, isTrue);
+    });
+
+        testWidgets(
+        'Given the custom switch widget set to false, When tapping the text the value changed to true',
+        (tester) async {
+      String label = 'test switch field';
+      bool initialValue = false;
+      bool? onSelectionChangedValue;
+      bool onSelectionChangedCalled = false;
+
+      onSelectionChanged(bool value) {
+        onSelectionChangedValue = value;
+        onSelectionChangedCalled = true;
+      }
+
+      await tester
+          .pumpWidget(createSwitch(label, onSelectionChanged, initialValue));
+
+      // Tap on the switch to change the value
+      await tester.tap(find.text(label));
+      await tester.pumpAndSettle();
+
+      expect(onSelectionChangedValue, isTrue);
+      expect(onSelectionChangedCalled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Tapping the label text next to a switch should do the same as tapping the switch.

Resolves #152 