### PR TITLE
feat: added link to 3rd party licenses

### DIFF
--- a/lib/app/home/views/about_screen.dart
+++ b/lib/app/home/views/about_screen.dart
@@ -20,8 +20,10 @@ class _AboutScreenState extends State<AboutScreen> {
       version: 'unknown',
       buildNumber: 'unknown');
 
-  final pensionCompareWebSiteUrl =
-      Uri(scheme: 'https', host: 'happybunnysoftware.co.uk', path: 'pension-compare');
+  final pensionCompareWebSiteUrl = Uri(
+      scheme: 'https',
+      host: 'happybunnysoftware.co.uk',
+      path: 'pension-compare');
 
   @override
   void initState() {
@@ -79,6 +81,12 @@ class _AboutScreenState extends State<AboutScreen> {
                       onPressed: () {
                         context.push(RouteDefs.policyViewer,
                             extra: PolicyType.privacyPolicy);
+                      },
+                    ),
+                    ElevatedButton(
+                      child: const Text('3rd Party Licenses'),
+                      onPressed: () {
+                        showLicensePage(context: context);
                       },
                     )
                   ],


### PR DESCRIPTION
Adds button to about screen to allow the user to view the license info for 3rd party libraries and packages used in the app

Resolves #151 